### PR TITLE
Phase 2: Categories, Property Enhancements, /me endpoint & fixes

### DIFF
--- a/src/main/java/com/rinoimob/api/controller/AuthController.java
+++ b/src/main/java/com/rinoimob/api/controller/AuthController.java
@@ -5,6 +5,7 @@ import com.rinoimob.domain.dto.IdentifyRequest;
 import com.rinoimob.domain.dto.IdentifyResponse;
 import com.rinoimob.domain.dto.LoginRequest;
 import com.rinoimob.domain.dto.LoginResponse;
+import com.rinoimob.domain.dto.MeResponse;
 import com.rinoimob.domain.dto.PasswordResetRequest;
 import com.rinoimob.domain.dto.RegisterRequest;
 import com.rinoimob.domain.dto.SelectTenantRequest;
@@ -14,6 +15,7 @@ import com.rinoimob.service.TenantService;
 import com.rinoimob.service.auth.AuthService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -22,6 +24,7 @@ import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Optional;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/v1/auth")
@@ -35,6 +38,16 @@ public class AuthController {
     public AuthController(AuthService authService, TenantService tenantService) {
         this.authService = authService;
         this.tenantService = tenantService;
+    }
+
+    @GetMapping("/me")
+    @Operation(summary = "Get current authenticated user and validate session")
+    public ResponseEntity<MeResponse> me(HttpServletRequest request) {
+        UUID userId = (UUID) request.getAttribute("userId");
+        if (userId == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Unauthorized");
+        }
+        return ResponseEntity.ok(authService.getMe(userId));
     }
 
     @PostMapping("/signup")

--- a/src/main/java/com/rinoimob/api/controller/CategoryController.java
+++ b/src/main/java/com/rinoimob/api/controller/CategoryController.java
@@ -1,0 +1,52 @@
+package com.rinoimob.api.controller;
+
+import com.rinoimob.domain.dto.CategoryResponse;
+import com.rinoimob.domain.dto.CreateCategoryRequest;
+import com.rinoimob.domain.dto.UpdateCategoryRequest;
+import com.rinoimob.service.CategoryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/categories")
+@Tag(name = "Categories", description = "Property category management")
+@RequiredArgsConstructor
+public class CategoryController {
+
+    private final CategoryService categoryService;
+
+    @GetMapping
+    @Operation(summary = "List all categories available to the current tenant (globals + own)")
+    public ResponseEntity<List<CategoryResponse>> list() {
+        return ResponseEntity.ok(categoryService.listAvailable());
+    }
+
+    @PostMapping
+    @Operation(summary = "Create a new category for the current tenant")
+    public ResponseEntity<CategoryResponse> create(@Valid @RequestBody CreateCategoryRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(categoryService.create(request));
+    }
+
+    @PutMapping("/{id}")
+    @Operation(summary = "Update an existing tenant-owned category")
+    public ResponseEntity<CategoryResponse> update(
+            @PathVariable UUID id,
+            @Valid @RequestBody UpdateCategoryRequest request) {
+        return ResponseEntity.ok(categoryService.update(id, request));
+    }
+
+    @DeleteMapping("/{id}")
+    @Operation(summary = "Delete a tenant-owned category")
+    public ResponseEntity<Void> delete(@PathVariable UUID id) {
+        categoryService.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/rinoimob/api/controller/PropertyController.java
+++ b/src/main/java/com/rinoimob/api/controller/PropertyController.java
@@ -1,0 +1,111 @@
+package com.rinoimob.api.controller;
+
+import com.rinoimob.domain.dto.property.*;
+import com.rinoimob.domain.enums.PropertyOperation;
+import com.rinoimob.domain.enums.PropertyStatus;
+import com.rinoimob.domain.enums.PropertyType;
+import com.rinoimob.service.PropertyService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/properties")
+@RequiredArgsConstructor
+public class PropertyController {
+
+    private final PropertyService propertyService;
+
+    @GetMapping
+    public ResponseEntity<Page<PropertySummaryResponse>> list(
+            @RequestParam(required = false) PropertyStatus status,
+            @RequestParam(required = false) PropertyOperation operation,
+            @RequestParam(required = false) PropertyType propertyType,
+            @RequestParam(required = false) BigDecimal minPrice,
+            @RequestParam(required = false) BigDecimal maxPrice,
+            @RequestParam(required = false) Integer bedrooms,
+            @RequestParam(required = false) String city,
+            @PageableDefault(size = 20, sort = "createdAt") Pageable pageable) {
+        return ResponseEntity.ok(propertyService.listProperties(
+                status, operation, propertyType, minPrice, maxPrice, bedrooms, city, pageable));
+    }
+
+    @PostMapping
+    public ResponseEntity<PropertyResponse> create(@Valid @RequestBody CreatePropertyRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(propertyService.createProperty(request));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<PropertyResponse> get(@PathVariable UUID id) {
+        return ResponseEntity.ok(propertyService.getProperty(id));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<PropertyResponse> update(
+            @PathVariable UUID id,
+            @RequestBody UpdatePropertyRequest request) {
+        return ResponseEntity.ok(propertyService.updateProperty(id, request));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable UUID id) {
+        propertyService.deleteProperty(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    // ── Photos ────────────────────────────────────────────────────────────────
+
+    @PostMapping(value = "/{id}/photos", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<PropertyPhotoResponse> uploadPhoto(
+            @PathVariable UUID id,
+            @RequestPart("file") MultipartFile file,
+            @RequestPart(value = "altText", required = false) String altText) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(propertyService.addPhoto(id, file, altText));
+    }
+
+    @PatchMapping("/{id}/photos/{photoId}/cover")
+    public ResponseEntity<Void> setCover(@PathVariable UUID id, @PathVariable UUID photoId) {
+        propertyService.setCoverPhoto(id, photoId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/{id}/photos/{photoId}")
+    public ResponseEntity<Void> deletePhoto(@PathVariable UUID id, @PathVariable UUID photoId) {
+        propertyService.deletePhoto(id, photoId);
+        return ResponseEntity.noContent().build();
+    }
+
+    // ── Floor Plans ───────────────────────────────────────────────────────────
+
+    @PostMapping("/{id}/floor-plans")
+    public ResponseEntity<FloorPlanResponse> addFloorPlan(
+            @PathVariable UUID id,
+            @Valid @RequestBody CreateFloorPlanRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(propertyService.addFloorPlan(id, request));
+    }
+
+    @DeleteMapping("/{id}/floor-plans/{planId}")
+    public ResponseEntity<Void> deleteFloorPlan(@PathVariable UUID id, @PathVariable UUID planId) {
+        propertyService.deleteFloorPlan(id, planId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping(value = "/{id}/floor-plans/{planId}/photos", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<FloorPlanPhotoResponse> uploadFloorPlanPhoto(
+            @PathVariable UUID id,
+            @PathVariable UUID planId,
+            @RequestPart("file") MultipartFile file) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(propertyService.addFloorPlanPhoto(id, planId, file));
+    }
+}

--- a/src/main/java/com/rinoimob/config/ApplicationConfig.java
+++ b/src/main/java/com/rinoimob/config/ApplicationConfig.java
@@ -1,10 +1,16 @@
 package com.rinoimob.config;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.web.client.RestTemplate;
 
 @Configuration
 @EnableAsync
 public class ApplicationConfig {
 
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
 }

--- a/src/main/java/com/rinoimob/domain/dto/CategoryResponse.java
+++ b/src/main/java/com/rinoimob/domain/dto/CategoryResponse.java
@@ -1,0 +1,14 @@
+package com.rinoimob.domain.dto;
+
+import java.util.UUID;
+
+public record CategoryResponse(
+    UUID id,
+    UUID tenantId,
+    String name,
+    String slug,
+    String color,
+    Boolean active,
+    Integer position,
+    boolean global
+) {}

--- a/src/main/java/com/rinoimob/domain/dto/CategoryResponse.java
+++ b/src/main/java/com/rinoimob/domain/dto/CategoryResponse.java
@@ -10,5 +10,5 @@ public record CategoryResponse(
     String color,
     Boolean active,
     Integer position,
-    boolean global
+    boolean isGlobal
 ) {}

--- a/src/main/java/com/rinoimob/domain/dto/CreateCategoryRequest.java
+++ b/src/main/java/com/rinoimob/domain/dto/CreateCategoryRequest.java
@@ -1,0 +1,12 @@
+package com.rinoimob.domain.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record CreateCategoryRequest(
+    @NotBlank @Size(max = 100) String name,
+    @NotBlank @Size(max = 100) @Pattern(regexp = "^[a-z0-9-]+$", message = "Slug must be lowercase alphanumeric with hyphens") String slug,
+    @Pattern(regexp = "^#[0-9A-Fa-f]{6}$", message = "Color must be a valid hex color") String color,
+    Integer position
+) {}

--- a/src/main/java/com/rinoimob/domain/dto/MeResponse.java
+++ b/src/main/java/com/rinoimob/domain/dto/MeResponse.java
@@ -1,0 +1,16 @@
+package com.rinoimob.domain.dto;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record MeResponse(
+    UUID id,
+    String email,
+    String firstName,
+    String lastName,
+    Boolean active,
+    LocalDateTime createdAt,
+    UUID tenantId,
+    String tenantName,
+    String tenantSubdomain
+) {}

--- a/src/main/java/com/rinoimob/domain/dto/UpdateCategoryRequest.java
+++ b/src/main/java/com/rinoimob/domain/dto/UpdateCategoryRequest.java
@@ -1,0 +1,12 @@
+package com.rinoimob.domain.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record UpdateCategoryRequest(
+    @NotBlank @Size(max = 100) String name,
+    @Pattern(regexp = "^#[0-9A-Fa-f]{6}$", message = "Color must be a valid hex color") String color,
+    Integer position,
+    Boolean active
+) {}

--- a/src/main/java/com/rinoimob/domain/dto/property/CreateFloorPlanRequest.java
+++ b/src/main/java/com/rinoimob/domain/dto/property/CreateFloorPlanRequest.java
@@ -1,0 +1,10 @@
+package com.rinoimob.domain.dto.property;
+
+import jakarta.validation.constraints.NotBlank;
+
+import java.math.BigDecimal;
+
+public record CreateFloorPlanRequest(
+        @NotBlank String name,
+        BigDecimal area
+) {}

--- a/src/main/java/com/rinoimob/domain/dto/property/CreatePropertyRequest.java
+++ b/src/main/java/com/rinoimob/domain/dto/property/CreatePropertyRequest.java
@@ -1,5 +1,6 @@
 package com.rinoimob.domain.dto.property;
 
+import com.rinoimob.domain.enums.PropertyCondition;
 import com.rinoimob.domain.enums.PropertyOperation;
 import com.rinoimob.domain.enums.PropertyStatus;
 import com.rinoimob.domain.enums.PropertyType;
@@ -7,7 +8,9 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 import java.math.BigDecimal;
+import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 public record CreatePropertyRequest(
         @NotBlank String title,
@@ -15,6 +18,8 @@ public record CreatePropertyRequest(
         @NotNull PropertyOperation operation,
         @NotNull PropertyType propertyType,
         PropertyStatus status,
+        PropertyCondition condition,
+        String referenceCode,
         BigDecimal price,
         String currency,
         BigDecimal taxes,
@@ -25,6 +30,7 @@ public record CreatePropertyRequest(
         Integer suites,
         Integer bathrooms,
         Integer parking,
+        Integer floorNumber,
         String addressStreet,
         String addressNumber,
         String addressComplement,
@@ -35,5 +41,6 @@ public record CreatePropertyRequest(
         String addressZip,
         BigDecimal lat,
         BigDecimal lng,
-        Map<String, Object> attributes
+        Map<String, Object> attributes,
+        List<UUID> categoryIds
 ) {}

--- a/src/main/java/com/rinoimob/domain/dto/property/CreatePropertyRequest.java
+++ b/src/main/java/com/rinoimob/domain/dto/property/CreatePropertyRequest.java
@@ -1,0 +1,39 @@
+package com.rinoimob.domain.dto.property;
+
+import com.rinoimob.domain.enums.PropertyOperation;
+import com.rinoimob.domain.enums.PropertyStatus;
+import com.rinoimob.domain.enums.PropertyType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.math.BigDecimal;
+import java.util.Map;
+
+public record CreatePropertyRequest(
+        @NotBlank String title,
+        String description,
+        @NotNull PropertyOperation operation,
+        @NotNull PropertyType propertyType,
+        PropertyStatus status,
+        BigDecimal price,
+        String currency,
+        BigDecimal taxes,
+        BigDecimal condoFee,
+        BigDecimal areaTotal,
+        BigDecimal areaUseful,
+        Integer bedrooms,
+        Integer suites,
+        Integer bathrooms,
+        Integer parking,
+        String addressStreet,
+        String addressNumber,
+        String addressComplement,
+        String addressNeighborhood,
+        String addressCity,
+        String addressState,
+        String addressCountry,
+        String addressZip,
+        BigDecimal lat,
+        BigDecimal lng,
+        Map<String, Object> attributes
+) {}

--- a/src/main/java/com/rinoimob/domain/dto/property/FloorPlanPhotoResponse.java
+++ b/src/main/java/com/rinoimob/domain/dto/property/FloorPlanPhotoResponse.java
@@ -1,0 +1,11 @@
+package com.rinoimob.domain.dto.property;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record FloorPlanPhotoResponse(
+        UUID id,
+        String url,
+        Integer position,
+        LocalDateTime createdAt
+) {}

--- a/src/main/java/com/rinoimob/domain/dto/property/FloorPlanResponse.java
+++ b/src/main/java/com/rinoimob/domain/dto/property/FloorPlanResponse.java
@@ -1,0 +1,14 @@
+package com.rinoimob.domain.dto.property;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+public record FloorPlanResponse(
+        UUID id,
+        String name,
+        BigDecimal area,
+        LocalDateTime createdAt,
+        List<FloorPlanPhotoResponse> photos
+) {}

--- a/src/main/java/com/rinoimob/domain/dto/property/PropertyPhotoResponse.java
+++ b/src/main/java/com/rinoimob/domain/dto/property/PropertyPhotoResponse.java
@@ -1,0 +1,13 @@
+package com.rinoimob.domain.dto.property;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record PropertyPhotoResponse(
+        UUID id,
+        String url,
+        Integer position,
+        Boolean isCover,
+        String altText,
+        LocalDateTime createdAt
+) {}

--- a/src/main/java/com/rinoimob/domain/dto/property/PropertyResponse.java
+++ b/src/main/java/com/rinoimob/domain/dto/property/PropertyResponse.java
@@ -1,5 +1,7 @@
 package com.rinoimob.domain.dto.property;
 
+import com.rinoimob.domain.dto.CategoryResponse;
+import com.rinoimob.domain.enums.PropertyCondition;
 import com.rinoimob.domain.enums.PropertyOperation;
 import com.rinoimob.domain.enums.PropertyStatus;
 import com.rinoimob.domain.enums.PropertyType;
@@ -17,6 +19,8 @@ public record PropertyResponse(
         PropertyOperation operation,
         PropertyType propertyType,
         PropertyStatus status,
+        PropertyCondition condition,
+        String referenceCode,
         BigDecimal price,
         String currency,
         BigDecimal taxes,
@@ -27,6 +31,7 @@ public record PropertyResponse(
         Integer suites,
         Integer bathrooms,
         Integer parking,
+        Integer floorNumber,
         String addressStreet,
         String addressNumber,
         String addressComplement,
@@ -39,6 +44,7 @@ public record PropertyResponse(
         BigDecimal lng,
         UUID coverPhotoId,
         Map<String, Object> attributes,
+        List<CategoryResponse> categories,
         LocalDateTime publishedAt,
         LocalDateTime createdAt,
         LocalDateTime updatedAt,

--- a/src/main/java/com/rinoimob/domain/dto/property/PropertyResponse.java
+++ b/src/main/java/com/rinoimob/domain/dto/property/PropertyResponse.java
@@ -1,0 +1,47 @@
+package com.rinoimob.domain.dto.property;
+
+import com.rinoimob.domain.enums.PropertyOperation;
+import com.rinoimob.domain.enums.PropertyStatus;
+import com.rinoimob.domain.enums.PropertyType;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+public record PropertyResponse(
+        UUID id,
+        String title,
+        String description,
+        PropertyOperation operation,
+        PropertyType propertyType,
+        PropertyStatus status,
+        BigDecimal price,
+        String currency,
+        BigDecimal taxes,
+        BigDecimal condoFee,
+        BigDecimal areaTotal,
+        BigDecimal areaUseful,
+        Integer bedrooms,
+        Integer suites,
+        Integer bathrooms,
+        Integer parking,
+        String addressStreet,
+        String addressNumber,
+        String addressComplement,
+        String addressNeighborhood,
+        String addressCity,
+        String addressState,
+        String addressCountry,
+        String addressZip,
+        BigDecimal lat,
+        BigDecimal lng,
+        UUID coverPhotoId,
+        Map<String, Object> attributes,
+        LocalDateTime publishedAt,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt,
+        List<PropertyPhotoResponse> photos,
+        List<FloorPlanResponse> floorPlans
+) {}

--- a/src/main/java/com/rinoimob/domain/dto/property/PropertySummaryResponse.java
+++ b/src/main/java/com/rinoimob/domain/dto/property/PropertySummaryResponse.java
@@ -1,11 +1,14 @@
 package com.rinoimob.domain.dto.property;
 
+import com.rinoimob.domain.dto.CategoryResponse;
+import com.rinoimob.domain.enums.PropertyCondition;
 import com.rinoimob.domain.enums.PropertyOperation;
 import com.rinoimob.domain.enums.PropertyStatus;
 import com.rinoimob.domain.enums.PropertyType;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 
 public record PropertySummaryResponse(
@@ -14,6 +17,8 @@ public record PropertySummaryResponse(
         PropertyOperation operation,
         PropertyType propertyType,
         PropertyStatus status,
+        PropertyCondition condition,
+        String referenceCode,
         BigDecimal price,
         String currency,
         BigDecimal areaTotal,
@@ -24,5 +29,6 @@ public record PropertySummaryResponse(
         String addressCountry,
         UUID coverPhotoId,
         String coverPhotoUrl,
+        List<CategoryResponse> categories,
         LocalDateTime createdAt
 ) {}

--- a/src/main/java/com/rinoimob/domain/dto/property/PropertySummaryResponse.java
+++ b/src/main/java/com/rinoimob/domain/dto/property/PropertySummaryResponse.java
@@ -1,0 +1,28 @@
+package com.rinoimob.domain.dto.property;
+
+import com.rinoimob.domain.enums.PropertyOperation;
+import com.rinoimob.domain.enums.PropertyStatus;
+import com.rinoimob.domain.enums.PropertyType;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record PropertySummaryResponse(
+        UUID id,
+        String title,
+        PropertyOperation operation,
+        PropertyType propertyType,
+        PropertyStatus status,
+        BigDecimal price,
+        String currency,
+        BigDecimal areaTotal,
+        Integer bedrooms,
+        Integer bathrooms,
+        String addressCity,
+        String addressState,
+        String addressCountry,
+        UUID coverPhotoId,
+        String coverPhotoUrl,
+        LocalDateTime createdAt
+) {}

--- a/src/main/java/com/rinoimob/domain/dto/property/UpdatePropertyRequest.java
+++ b/src/main/java/com/rinoimob/domain/dto/property/UpdatePropertyRequest.java
@@ -1,11 +1,14 @@
 package com.rinoimob.domain.dto.property;
 
+import com.rinoimob.domain.enums.PropertyCondition;
 import com.rinoimob.domain.enums.PropertyOperation;
 import com.rinoimob.domain.enums.PropertyStatus;
 import com.rinoimob.domain.enums.PropertyType;
 
 import java.math.BigDecimal;
+import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 public record UpdatePropertyRequest(
         String title,
@@ -13,6 +16,8 @@ public record UpdatePropertyRequest(
         PropertyOperation operation,
         PropertyType propertyType,
         PropertyStatus status,
+        PropertyCondition condition,
+        String referenceCode,
         BigDecimal price,
         String currency,
         BigDecimal taxes,
@@ -23,6 +28,7 @@ public record UpdatePropertyRequest(
         Integer suites,
         Integer bathrooms,
         Integer parking,
+        Integer floorNumber,
         String addressStreet,
         String addressNumber,
         String addressComplement,
@@ -33,5 +39,6 @@ public record UpdatePropertyRequest(
         String addressZip,
         BigDecimal lat,
         BigDecimal lng,
-        Map<String, Object> attributes
+        Map<String, Object> attributes,
+        List<UUID> categoryIds
 ) {}

--- a/src/main/java/com/rinoimob/domain/dto/property/UpdatePropertyRequest.java
+++ b/src/main/java/com/rinoimob/domain/dto/property/UpdatePropertyRequest.java
@@ -1,0 +1,37 @@
+package com.rinoimob.domain.dto.property;
+
+import com.rinoimob.domain.enums.PropertyOperation;
+import com.rinoimob.domain.enums.PropertyStatus;
+import com.rinoimob.domain.enums.PropertyType;
+
+import java.math.BigDecimal;
+import java.util.Map;
+
+public record UpdatePropertyRequest(
+        String title,
+        String description,
+        PropertyOperation operation,
+        PropertyType propertyType,
+        PropertyStatus status,
+        BigDecimal price,
+        String currency,
+        BigDecimal taxes,
+        BigDecimal condoFee,
+        BigDecimal areaTotal,
+        BigDecimal areaUseful,
+        Integer bedrooms,
+        Integer suites,
+        Integer bathrooms,
+        Integer parking,
+        String addressStreet,
+        String addressNumber,
+        String addressComplement,
+        String addressNeighborhood,
+        String addressCity,
+        String addressState,
+        String addressCountry,
+        String addressZip,
+        BigDecimal lat,
+        BigDecimal lng,
+        Map<String, Object> attributes
+) {}

--- a/src/main/java/com/rinoimob/domain/entity/FloorPlan.java
+++ b/src/main/java/com/rinoimob/domain/entity/FloorPlan.java
@@ -1,0 +1,46 @@
+package com.rinoimob.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@Table(name = "floor_plans")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class FloorPlan {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "property_id", nullable = false)
+    private Property property;
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @Column(precision = 10, scale = 2)
+    private BigDecimal area;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @OneToMany(mappedBy = "floorPlan", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("position ASC")
+    private List<FloorPlanPhoto> photos = new ArrayList<>();
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/rinoimob/domain/entity/FloorPlanPhoto.java
+++ b/src/main/java/com/rinoimob/domain/entity/FloorPlanPhoto.java
@@ -1,0 +1,42 @@
+package com.rinoimob.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "floor_plan_photos")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class FloorPlanPhoto {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "floor_plan_id", nullable = false)
+    private FloorPlan floorPlan;
+
+    @Column(name = "seaweed_fid", nullable = false, length = 100)
+    private String seaweedFid;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String url;
+
+    @Column(nullable = false)
+    private Integer position = 0;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/rinoimob/domain/entity/Property.java
+++ b/src/main/java/com/rinoimob/domain/entity/Property.java
@@ -1,12 +1,21 @@
 package com.rinoimob.domain.entity;
 
+import com.rinoimob.domain.enums.PropertyOperation;
+import com.rinoimob.domain.enums.PropertyStatus;
+import com.rinoimob.domain.enums.PropertyType;
+import io.hypersistence.utils.hibernate.type.json.JsonBinaryType;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Type;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 @Entity
@@ -20,49 +29,106 @@ public class Property {
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 
-    @Column(nullable = false)
+    @Column(name = "tenant_id", nullable = false)
     private UUID tenantId;
 
-    @Column(nullable = false)
-    private String address;
+    @Column(nullable = false, length = 200)
+    private String title;
 
-    @Column(nullable = false)
-    private String city;
+    @Column(columnDefinition = "TEXT")
+    private String description;
 
-    private String state;
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private PropertyOperation operation;
 
-    @Column(name = "zip_code")
-    private String zipCode;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "property_type", nullable = false, length = 20)
+    private PropertyType propertyType;
 
-    @Column(nullable = false)
-    private String country;
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private PropertyStatus status = PropertyStatus.DRAFT;
 
-    @Column(name = "property_type")
-    private String propertyType;
+    @Column(precision = 14, scale = 2)
+    private BigDecimal price;
 
-    private Integer units = 1;
+    @Column(length = 3, nullable = false)
+    private String currency = "BRL";
+
+    @Column(precision = 14, scale = 2)
+    private BigDecimal taxes;
+
+    @Column(name = "condo_fee", precision = 14, scale = 2)
+    private BigDecimal condoFee;
+
+    @Column(name = "area_total", precision = 10, scale = 2)
+    private BigDecimal areaTotal;
+
+    @Column(name = "area_useful", precision = 10, scale = 2)
+    private BigDecimal areaUseful;
 
     private Integer bedrooms;
+    private Integer suites;
+    private Integer bathrooms;
+    private Integer parking;
 
-    private BigDecimal bathrooms;
+    @Column(name = "address_street")
+    private String addressStreet;
 
-    @Column(name = "square_feet")
-    private Integer squareFeet;
+    @Column(name = "address_number", length = 20)
+    private String addressNumber;
 
-    @Column(name = "annual_rent")
-    private BigDecimal annualRent;
+    @Column(name = "address_complement", length = 100)
+    private String addressComplement;
 
-    @Column(name = "owner_id")
-    private UUID ownerId;
+    @Column(name = "address_neighborhood", length = 100)
+    private String addressNeighborhood;
 
-    @Column(nullable = false)
-    private Boolean active = true;
+    @Column(name = "address_city", length = 100)
+    private String addressCity;
+
+    @Column(name = "address_state", length = 100)
+    private String addressState;
+
+    @Column(name = "address_country", length = 2, nullable = false)
+    private String addressCountry = "BR";
+
+    @Column(name = "address_zip", length = 20)
+    private String addressZip;
+
+    @Column(precision = 10, scale = 7)
+    private BigDecimal lat;
+
+    @Column(precision = 10, scale = 7)
+    private BigDecimal lng;
+
+    @Column(name = "cover_photo_id")
+    private UUID coverPhotoId;
+
+    @Type(JsonBinaryType.class)
+    @Column(columnDefinition = "jsonb", nullable = false)
+    private Map<String, Object> attributes = new HashMap<>();
+
+    @Column(name = "published_at")
+    private LocalDateTime publishedAt;
 
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    @OneToMany(mappedBy = "property", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("position ASC")
+    private List<PropertyPhoto> photos = new ArrayList<>();
+
+    @OneToMany(mappedBy = "property", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("createdAt ASC")
+    private List<FloorPlan> floorPlans = new ArrayList<>();
 
     @PrePersist
     protected void onCreate() {
@@ -74,5 +140,4 @@ public class Property {
     protected void onUpdate() {
         updatedAt = LocalDateTime.now();
     }
-
 }

--- a/src/main/java/com/rinoimob/domain/entity/Property.java
+++ b/src/main/java/com/rinoimob/domain/entity/Property.java
@@ -1,5 +1,6 @@
 package com.rinoimob.domain.entity;
 
+import com.rinoimob.domain.enums.PropertyCondition;
 import com.rinoimob.domain.enums.PropertyOperation;
 import com.rinoimob.domain.enums.PropertyStatus;
 import com.rinoimob.domain.enums.PropertyType;
@@ -14,8 +15,10 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 @Entity
@@ -105,6 +108,24 @@ public class Property {
 
     @Column(name = "cover_photo_id")
     private UUID coverPhotoId;
+
+    @Column(name = "reference_code", length = 50)
+    private String referenceCode;
+
+    @Column(name = "floor_number")
+    private Integer floorNumber;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "condition", length = 30)
+    private PropertyCondition condition;
+
+    @ManyToMany(fetch = FetchType.LAZY)
+    @JoinTable(
+            name = "property_category_map",
+            joinColumns = @JoinColumn(name = "property_id"),
+            inverseJoinColumns = @JoinColumn(name = "category_id")
+    )
+    private Set<PropertyCategory> categories = new HashSet<>();
 
     @Type(JsonBinaryType.class)
     @Column(columnDefinition = "jsonb", nullable = false)

--- a/src/main/java/com/rinoimob/domain/entity/PropertyCategory.java
+++ b/src/main/java/com/rinoimob/domain/entity/PropertyCategory.java
@@ -1,0 +1,61 @@
+package com.rinoimob.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "property_categories")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class PropertyCategory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    /** NULL means this is a global/system category. Non-null means tenant-owned. */
+    @Column(name = "tenant_id")
+    private UUID tenantId;
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @Column(nullable = false, length = 100)
+    private String slug;
+
+    @Column(length = 7)
+    private String color;
+
+    @Column(nullable = false)
+    private Boolean active = true;
+
+    @Column(nullable = false)
+    private Integer position = 0;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    public boolean isGlobal() {
+        return tenantId == null;
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/rinoimob/domain/entity/PropertyPhoto.java
+++ b/src/main/java/com/rinoimob/domain/entity/PropertyPhoto.java
@@ -1,0 +1,48 @@
+package com.rinoimob.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "property_photos")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class PropertyPhoto {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "property_id", nullable = false)
+    private Property property;
+
+    @Column(name = "seaweed_fid", nullable = false, length = 100)
+    private String seaweedFid;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String url;
+
+    @Column(nullable = false)
+    private Integer position = 0;
+
+    @Column(name = "is_cover", nullable = false)
+    private Boolean isCover = false;
+
+    @Column(name = "alt_text", length = 255)
+    private String altText;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/rinoimob/domain/enums/PropertyCondition.java
+++ b/src/main/java/com/rinoimob/domain/enums/PropertyCondition.java
@@ -1,0 +1,7 @@
+package com.rinoimob.domain.enums;
+
+public enum PropertyCondition {
+    NEW,
+    USED,
+    UNDER_CONSTRUCTION
+}

--- a/src/main/java/com/rinoimob/domain/enums/PropertyOperation.java
+++ b/src/main/java/com/rinoimob/domain/enums/PropertyOperation.java
@@ -1,0 +1,7 @@
+package com.rinoimob.domain.enums;
+
+public enum PropertyOperation {
+    SALE,
+    RENT,
+    SEASONAL
+}

--- a/src/main/java/com/rinoimob/domain/enums/PropertyStatus.java
+++ b/src/main/java/com/rinoimob/domain/enums/PropertyStatus.java
@@ -1,0 +1,9 @@
+package com.rinoimob.domain.enums;
+
+public enum PropertyStatus {
+    DRAFT,
+    ACTIVE,
+    RESERVED,
+    SOLD,
+    ARCHIVED
+}

--- a/src/main/java/com/rinoimob/domain/enums/PropertyType.java
+++ b/src/main/java/com/rinoimob/domain/enums/PropertyType.java
@@ -1,0 +1,9 @@
+package com.rinoimob.domain.enums;
+
+public enum PropertyType {
+    HOUSE,
+    APARTMENT,
+    LAND,
+    COMMERCIAL,
+    RURAL
+}

--- a/src/main/java/com/rinoimob/domain/repository/FloorPlanPhotoRepository.java
+++ b/src/main/java/com/rinoimob/domain/repository/FloorPlanPhotoRepository.java
@@ -1,0 +1,16 @@
+package com.rinoimob.domain.repository;
+
+import com.rinoimob.domain.entity.FloorPlanPhoto;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface FloorPlanPhotoRepository extends JpaRepository<FloorPlanPhoto, UUID> {
+
+    List<FloorPlanPhoto> findByFloorPlanIdOrderByPositionAsc(UUID floorPlanId);
+
+    int countByFloorPlanId(UUID floorPlanId);
+}

--- a/src/main/java/com/rinoimob/domain/repository/FloorPlanRepository.java
+++ b/src/main/java/com/rinoimob/domain/repository/FloorPlanRepository.java
@@ -1,0 +1,17 @@
+package com.rinoimob.domain.repository;
+
+import com.rinoimob.domain.entity.FloorPlan;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface FloorPlanRepository extends JpaRepository<FloorPlan, UUID> {
+
+    List<FloorPlan> findByPropertyIdOrderByCreatedAtAsc(UUID propertyId);
+
+    Optional<FloorPlan> findByIdAndPropertyId(UUID id, UUID propertyId);
+}

--- a/src/main/java/com/rinoimob/domain/repository/PropertyCategoryRepository.java
+++ b/src/main/java/com/rinoimob/domain/repository/PropertyCategoryRepository.java
@@ -1,0 +1,24 @@
+package com.rinoimob.domain.repository;
+
+import com.rinoimob.domain.entity.PropertyCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface PropertyCategoryRepository extends JpaRepository<PropertyCategory, UUID> {
+
+    /** Returns global categories + tenant's own, ordered by position then name. */
+    @Query("SELECT c FROM PropertyCategory c WHERE (c.tenantId IS NULL OR c.tenantId = :tenantId) AND c.active = true ORDER BY c.position ASC, c.name ASC")
+    List<PropertyCategory> findAvailableForTenant(@Param("tenantId") UUID tenantId);
+
+    @Query("SELECT c FROM PropertyCategory c WHERE c.tenantId = :tenantId ORDER BY c.position ASC, c.name ASC")
+    List<PropertyCategory> findByTenantId(@Param("tenantId") UUID tenantId);
+
+    Optional<PropertyCategory> findBySlugAndTenantId(String slug, UUID tenantId);
+
+    boolean existsBySlugAndTenantId(String slug, UUID tenantId);
+}

--- a/src/main/java/com/rinoimob/domain/repository/PropertyPhotoRepository.java
+++ b/src/main/java/com/rinoimob/domain/repository/PropertyPhotoRepository.java
@@ -1,0 +1,19 @@
+package com.rinoimob.domain.repository;
+
+import com.rinoimob.domain.entity.PropertyPhoto;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface PropertyPhotoRepository extends JpaRepository<PropertyPhoto, UUID> {
+
+    List<PropertyPhoto> findByPropertyIdOrderByPositionAsc(UUID propertyId);
+
+    Optional<PropertyPhoto> findByIdAndPropertyId(UUID id, UUID propertyId);
+
+    int countByPropertyId(UUID propertyId);
+}

--- a/src/main/java/com/rinoimob/domain/repository/PropertyRepository.java
+++ b/src/main/java/com/rinoimob/domain/repository/PropertyRepository.java
@@ -1,19 +1,45 @@
 package com.rinoimob.domain.repository;
 
 import com.rinoimob.domain.entity.Property;
+import com.rinoimob.domain.enums.PropertyOperation;
+import com.rinoimob.domain.enums.PropertyStatus;
+import com.rinoimob.domain.enums.PropertyType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
+import java.math.BigDecimal;
+import java.util.Optional;
 import java.util.UUID;
 
 @Repository
 public interface PropertyRepository extends JpaRepository<Property, UUID> {
 
-    List<Property> findByTenantId(UUID tenantId);
+    Optional<Property> findByIdAndTenantIdAndDeletedAtIsNull(UUID id, UUID tenantId);
 
-    List<Property> findByTenantIdAndActive(UUID tenantId, Boolean active);
-
-    List<Property> findByTenantIdAndOwnerId(UUID tenantId, UUID ownerId);
-
+    @Query("""
+        SELECT p FROM Property p
+        WHERE p.tenantId = :tenantId
+          AND p.deletedAt IS NULL
+          AND (:status IS NULL OR p.status = :status)
+          AND (:operation IS NULL OR p.operation = :operation)
+          AND (:propertyType IS NULL OR p.propertyType = :propertyType)
+          AND (:minPrice IS NULL OR p.price >= :minPrice)
+          AND (:maxPrice IS NULL OR p.price <= :maxPrice)
+          AND (:bedrooms IS NULL OR p.bedrooms >= :bedrooms)
+          AND (:city IS NULL OR LOWER(p.addressCity) LIKE LOWER(CONCAT('%', :city, '%')))
+        """)
+    Page<Property> findWithFilters(
+            @Param("tenantId") UUID tenantId,
+            @Param("status") PropertyStatus status,
+            @Param("operation") PropertyOperation operation,
+            @Param("propertyType") PropertyType propertyType,
+            @Param("minPrice") BigDecimal minPrice,
+            @Param("maxPrice") BigDecimal maxPrice,
+            @Param("bedrooms") Integer bedrooms,
+            @Param("city") String city,
+            Pageable pageable);
 }

--- a/src/main/java/com/rinoimob/domain/repository/PropertyRepository.java
+++ b/src/main/java/com/rinoimob/domain/repository/PropertyRepository.java
@@ -1,45 +1,15 @@
 package com.rinoimob.domain.repository;
 
 import com.rinoimob.domain.entity.Property;
-import com.rinoimob.domain.enums.PropertyOperation;
-import com.rinoimob.domain.enums.PropertyStatus;
-import com.rinoimob.domain.enums.PropertyType;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
-import java.math.BigDecimal;
 import java.util.Optional;
 import java.util.UUID;
 
 @Repository
-public interface PropertyRepository extends JpaRepository<Property, UUID> {
+public interface PropertyRepository extends JpaRepository<Property, UUID>, JpaSpecificationExecutor<Property> {
 
     Optional<Property> findByIdAndTenantIdAndDeletedAtIsNull(UUID id, UUID tenantId);
-
-    @Query("""
-        SELECT p FROM Property p
-        WHERE p.tenantId = :tenantId
-          AND p.deletedAt IS NULL
-          AND (:status IS NULL OR p.status = :status)
-          AND (:operation IS NULL OR p.operation = :operation)
-          AND (:propertyType IS NULL OR p.propertyType = :propertyType)
-          AND (:minPrice IS NULL OR p.price >= :minPrice)
-          AND (:maxPrice IS NULL OR p.price <= :maxPrice)
-          AND (:bedrooms IS NULL OR p.bedrooms >= :bedrooms)
-          AND (:city IS NULL OR LOWER(p.addressCity) LIKE LOWER(CONCAT('%', :city, '%')))
-        """)
-    Page<Property> findWithFilters(
-            @Param("tenantId") UUID tenantId,
-            @Param("status") PropertyStatus status,
-            @Param("operation") PropertyOperation operation,
-            @Param("propertyType") PropertyType propertyType,
-            @Param("minPrice") BigDecimal minPrice,
-            @Param("maxPrice") BigDecimal maxPrice,
-            @Param("bedrooms") Integer bedrooms,
-            @Param("city") String city,
-            Pageable pageable);
 }

--- a/src/main/java/com/rinoimob/domain/repository/PropertySpecification.java
+++ b/src/main/java/com/rinoimob/domain/repository/PropertySpecification.java
@@ -1,0 +1,61 @@
+package com.rinoimob.domain.repository;
+
+import com.rinoimob.domain.entity.Property;
+import com.rinoimob.domain.enums.PropertyOperation;
+import com.rinoimob.domain.enums.PropertyStatus;
+import com.rinoimob.domain.enums.PropertyType;
+import jakarta.persistence.criteria.Predicate;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+public class PropertySpecification {
+
+    public static Specification<Property> withFilters(
+            UUID tenantId,
+            PropertyStatus status,
+            PropertyOperation operation,
+            PropertyType propertyType,
+            BigDecimal minPrice,
+            BigDecimal maxPrice,
+            Integer bedrooms,
+            String city) {
+
+        return (root, query, cb) -> {
+            List<Predicate> predicates = new ArrayList<>();
+
+            predicates.add(cb.equal(root.get("tenantId"), tenantId));
+            predicates.add(cb.isNull(root.get("deletedAt")));
+
+            if (status != null) {
+                predicates.add(cb.equal(root.get("status"), status));
+            }
+            if (operation != null) {
+                predicates.add(cb.equal(root.get("operation"), operation));
+            }
+            if (propertyType != null) {
+                predicates.add(cb.equal(root.get("propertyType"), propertyType));
+            }
+            if (minPrice != null) {
+                predicates.add(cb.greaterThanOrEqualTo(root.get("price"), minPrice));
+            }
+            if (maxPrice != null) {
+                predicates.add(cb.lessThanOrEqualTo(root.get("price"), maxPrice));
+            }
+            if (bedrooms != null) {
+                predicates.add(cb.greaterThanOrEqualTo(root.get("bedrooms"), bedrooms));
+            }
+            if (city != null && !city.isBlank()) {
+                predicates.add(cb.like(
+                        cb.lower(root.get("addressCity")),
+                        "%" + city.toLowerCase() + "%"
+                ));
+            }
+
+            return cb.and(predicates.toArray(new Predicate[0]));
+        };
+    }
+}

--- a/src/main/java/com/rinoimob/service/CategoryService.java
+++ b/src/main/java/com/rinoimob/service/CategoryService.java
@@ -1,0 +1,99 @@
+package com.rinoimob.service;
+
+import com.rinoimob.context.TenantContext;
+import com.rinoimob.domain.dto.CategoryResponse;
+import com.rinoimob.domain.dto.CreateCategoryRequest;
+import com.rinoimob.domain.dto.UpdateCategoryRequest;
+import com.rinoimob.domain.entity.PropertyCategory;
+import com.rinoimob.domain.repository.PropertyCategoryRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CategoryService {
+
+    private final PropertyCategoryRepository categoryRepository;
+
+    /** Returns global categories + current tenant's own categories. */
+    public List<CategoryResponse> listAvailable() {
+        UUID tenantId = currentTenantId();
+        return categoryRepository.findAvailableForTenant(tenantId)
+                .stream().map(this::toResponse).toList();
+    }
+
+    @Transactional
+    public CategoryResponse create(CreateCategoryRequest request) {
+        UUID tenantId = currentTenantId();
+
+        if (categoryRepository.existsBySlugAndTenantId(request.slug(), tenantId)) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "A category with this slug already exists");
+        }
+
+        PropertyCategory category = new PropertyCategory();
+        category.setTenantId(tenantId);
+        category.setName(request.name());
+        category.setSlug(request.slug());
+        category.setColor(request.color());
+        category.setPosition(request.position() != null ? request.position() : 0);
+        category.setActive(true);
+
+        PropertyCategory saved = categoryRepository.save(category);
+        log.info("Category created id={} tenant={}", saved.getId(), tenantId);
+        return toResponse(saved);
+    }
+
+    @Transactional
+    public CategoryResponse update(UUID id, UpdateCategoryRequest request) {
+        UUID tenantId = currentTenantId();
+        PropertyCategory category = getOwnedCategory(id, tenantId);
+
+        category.setName(request.name());
+        if (request.color() != null) category.setColor(request.color());
+        if (request.position() != null) category.setPosition(request.position());
+        if (request.active() != null) category.setActive(request.active());
+
+        PropertyCategory saved = categoryRepository.save(category);
+        log.info("Category updated id={} tenant={}", id, tenantId);
+        return toResponse(saved);
+    }
+
+    @Transactional
+    public void delete(UUID id) {
+        UUID tenantId = currentTenantId();
+        PropertyCategory category = getOwnedCategory(id, tenantId);
+        categoryRepository.delete(category);
+        log.info("Category deleted id={} tenant={}", id, tenantId);
+    }
+
+    private PropertyCategory getOwnedCategory(UUID id, UUID tenantId) {
+        PropertyCategory category = categoryRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Category not found"));
+        if (category.isGlobal()) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Cannot modify global categories");
+        }
+        if (!tenantId.equals(category.getTenantId())) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Category does not belong to this tenant");
+        }
+        return category;
+    }
+
+    private UUID currentTenantId() {
+        String id = TenantContext.getTenantId();
+        if (id == null) throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "No tenant context");
+        return UUID.fromString(id);
+    }
+
+    public CategoryResponse toResponse(PropertyCategory c) {
+        return new CategoryResponse(c.getId(), c.getTenantId(), c.getName(), c.getSlug(),
+                c.getColor(), c.getActive(), c.getPosition(), c.isGlobal());
+    }
+}

--- a/src/main/java/com/rinoimob/service/PropertyService.java
+++ b/src/main/java/com/rinoimob/service/PropertyService.java
@@ -4,11 +4,13 @@ import com.rinoimob.domain.dto.property.*;
 import com.rinoimob.domain.entity.FloorPlan;
 import com.rinoimob.domain.entity.FloorPlanPhoto;
 import com.rinoimob.domain.entity.Property;
+import com.rinoimob.domain.entity.PropertyCategory;
 import com.rinoimob.domain.entity.PropertyPhoto;
 import com.rinoimob.domain.enums.PropertyOperation;
 import com.rinoimob.domain.enums.PropertyStatus;
 import com.rinoimob.domain.enums.PropertyType;
 import com.rinoimob.domain.repository.FloorPlanPhotoRepository;
+import com.rinoimob.domain.repository.PropertyCategoryRepository;
 import com.rinoimob.domain.repository.PropertySpecification;
 import com.rinoimob.domain.repository.FloorPlanRepository;
 import com.rinoimob.domain.repository.PropertyPhotoRepository;
@@ -27,7 +29,9 @@ import org.springframework.web.server.ResponseStatusException;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 @Service
@@ -39,7 +43,9 @@ public class PropertyService {
     private final PropertyPhotoRepository photoRepository;
     private final FloorPlanRepository floorPlanRepository;
     private final FloorPlanPhotoRepository floorPlanPhotoRepository;
+    private final PropertyCategoryRepository categoryRepository;
     private final FileStorageService fileStorageService;
+    private final CategoryService categoryService;
 
     // ── CRUD ─────────────────────────────────────────────────────────────────
 
@@ -226,6 +232,8 @@ public class PropertyService {
         p.setDescription(req.description());
         p.setOperation(req.operation());
         p.setPropertyType(req.propertyType());
+        p.setCondition(req.condition());
+        p.setReferenceCode(req.referenceCode());
         p.setPrice(req.price());
         p.setCurrency(req.currency() != null ? req.currency() : "BRL");
         p.setTaxes(req.taxes());
@@ -236,6 +244,7 @@ public class PropertyService {
         p.setSuites(req.suites());
         p.setBathrooms(req.bathrooms());
         p.setParking(req.parking());
+        p.setFloorNumber(req.floorNumber());
         p.setAddressStreet(req.addressStreet());
         p.setAddressNumber(req.addressNumber());
         p.setAddressComplement(req.addressComplement());
@@ -247,6 +256,7 @@ public class PropertyService {
         p.setLat(req.lat());
         p.setLng(req.lng());
         if (req.attributes() != null) p.setAttributes(req.attributes());
+        if (req.categoryIds() != null) p.setCategories(resolveCategories(req.categoryIds()));
     }
 
     private void applyUpdate(Property p, UpdatePropertyRequest req) {
@@ -254,6 +264,8 @@ public class PropertyService {
         if (req.description() != null) p.setDescription(req.description());
         if (req.operation() != null) p.setOperation(req.operation());
         if (req.propertyType() != null) p.setPropertyType(req.propertyType());
+        if (req.condition() != null) p.setCondition(req.condition());
+        if (req.referenceCode() != null) p.setReferenceCode(req.referenceCode());
         if (req.status() != null) {
             p.setStatus(req.status());
             if (req.status() == PropertyStatus.ACTIVE && p.getPublishedAt() == null) {
@@ -270,6 +282,7 @@ public class PropertyService {
         if (req.suites() != null) p.setSuites(req.suites());
         if (req.bathrooms() != null) p.setBathrooms(req.bathrooms());
         if (req.parking() != null) p.setParking(req.parking());
+        if (req.floorNumber() != null) p.setFloorNumber(req.floorNumber());
         if (req.addressStreet() != null) p.setAddressStreet(req.addressStreet());
         if (req.addressNumber() != null) p.setAddressNumber(req.addressNumber());
         if (req.addressComplement() != null) p.setAddressComplement(req.addressComplement());
@@ -281,20 +294,41 @@ public class PropertyService {
         if (req.lat() != null) p.setLat(req.lat());
         if (req.lng() != null) p.setLng(req.lng());
         if (req.attributes() != null) p.setAttributes(req.attributes());
+        if (req.categoryIds() != null) p.setCategories(resolveCategories(req.categoryIds()));
+    }
+
+    private Set<PropertyCategory> resolveCategories(List<UUID> ids) {
+        if (ids == null || ids.isEmpty()) return new HashSet<>();
+        UUID tenantId = UUID.fromString(TenantContext.getTenantId());
+        Set<PropertyCategory> resolved = new HashSet<>();
+        for (UUID catId : ids) {
+            categoryRepository.findById(catId).ifPresent(cat -> {
+                // Allow global or own-tenant categories only
+                if (cat.isGlobal() || tenantId.equals(cat.getTenantId())) {
+                    resolved.add(cat);
+                }
+            });
+        }
+        return resolved;
     }
 
     private PropertyResponse toResponse(Property p) {
+        List<com.rinoimob.domain.dto.CategoryResponse> cats = p.getCategories().stream()
+                .map(categoryService::toResponse).toList();
         return new PropertyResponse(
                 p.getId(), p.getTitle(), p.getDescription(),
                 p.getOperation(), p.getPropertyType(), p.getStatus(),
+                p.getCondition(), p.getReferenceCode(),
                 p.getPrice(), p.getCurrency(), p.getTaxes(), p.getCondoFee(),
                 p.getAreaTotal(), p.getAreaUseful(),
                 p.getBedrooms(), p.getSuites(), p.getBathrooms(), p.getParking(),
+                p.getFloorNumber(),
                 p.getAddressStreet(), p.getAddressNumber(), p.getAddressComplement(),
                 p.getAddressNeighborhood(), p.getAddressCity(), p.getAddressState(),
                 p.getAddressCountry(), p.getAddressZip(),
                 p.getLat(), p.getLng(), p.getCoverPhotoId(),
-                p.getAttributes(), p.getPublishedAt(), p.getCreatedAt(), p.getUpdatedAt(),
+                p.getAttributes(), cats,
+                p.getPublishedAt(), p.getCreatedAt(), p.getUpdatedAt(),
                 p.getPhotos().stream().map(this::toPhotoResponse).toList(),
                 p.getFloorPlans().stream().map(this::toFloorPlanResponse).toList()
         );
@@ -306,11 +340,14 @@ public class PropertyService {
                 .findFirst()
                 .map(PropertyPhoto::getUrl)
                 .orElse(null);
+        List<com.rinoimob.domain.dto.CategoryResponse> cats = p.getCategories().stream()
+                .map(categoryService::toResponse).toList();
         return new PropertySummaryResponse(
                 p.getId(), p.getTitle(), p.getOperation(), p.getPropertyType(), p.getStatus(),
+                p.getCondition(), p.getReferenceCode(),
                 p.getPrice(), p.getCurrency(), p.getAreaTotal(), p.getBedrooms(), p.getBathrooms(),
                 p.getAddressCity(), p.getAddressState(), p.getAddressCountry(),
-                p.getCoverPhotoId(), coverUrl, p.getCreatedAt()
+                p.getCoverPhotoId(), coverUrl, cats, p.getCreatedAt()
         );
     }
 

--- a/src/main/java/com/rinoimob/service/PropertyService.java
+++ b/src/main/java/com/rinoimob/service/PropertyService.java
@@ -9,6 +9,7 @@ import com.rinoimob.domain.enums.PropertyOperation;
 import com.rinoimob.domain.enums.PropertyStatus;
 import com.rinoimob.domain.enums.PropertyType;
 import com.rinoimob.domain.repository.FloorPlanPhotoRepository;
+import com.rinoimob.domain.repository.PropertySpecification;
 import com.rinoimob.domain.repository.FloorPlanRepository;
 import com.rinoimob.domain.repository.PropertyPhotoRepository;
 import com.rinoimob.domain.repository.PropertyRepository;
@@ -87,8 +88,10 @@ public class PropertyService {
             String city,
             Pageable pageable) {
         UUID tenantId = UUID.fromString(TenantContext.getTenantId());
-        return propertyRepository.findWithFilters(
-                tenantId, status, operation, propertyType, minPrice, maxPrice, bedrooms, city, pageable)
+        return propertyRepository.findAll(
+                PropertySpecification.withFilters(
+                        tenantId, status, operation, propertyType, minPrice, maxPrice, bedrooms, city),
+                pageable)
                 .map(this::toSummary);
     }
 

--- a/src/main/java/com/rinoimob/service/PropertyService.java
+++ b/src/main/java/com/rinoimob/service/PropertyService.java
@@ -1,0 +1,327 @@
+package com.rinoimob.service;
+
+import com.rinoimob.domain.dto.property.*;
+import com.rinoimob.domain.entity.FloorPlan;
+import com.rinoimob.domain.entity.FloorPlanPhoto;
+import com.rinoimob.domain.entity.Property;
+import com.rinoimob.domain.entity.PropertyPhoto;
+import com.rinoimob.domain.enums.PropertyOperation;
+import com.rinoimob.domain.enums.PropertyStatus;
+import com.rinoimob.domain.enums.PropertyType;
+import com.rinoimob.domain.repository.FloorPlanPhotoRepository;
+import com.rinoimob.domain.repository.FloorPlanRepository;
+import com.rinoimob.domain.repository.PropertyPhotoRepository;
+import com.rinoimob.domain.repository.PropertyRepository;
+import com.rinoimob.service.storage.FileStorageService;
+import com.rinoimob.context.TenantContext;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class PropertyService {
+
+    private final PropertyRepository propertyRepository;
+    private final PropertyPhotoRepository photoRepository;
+    private final FloorPlanRepository floorPlanRepository;
+    private final FloorPlanPhotoRepository floorPlanPhotoRepository;
+    private final FileStorageService fileStorageService;
+
+    // ── CRUD ─────────────────────────────────────────────────────────────────
+
+    @Transactional
+    public PropertyResponse createProperty(CreatePropertyRequest req) {
+        UUID tenantId = UUID.fromString(TenantContext.getTenantId());
+        Property property = new Property();
+        property.setTenantId(tenantId);
+        applyRequest(property, req);
+        property.setStatus(req.status() != null ? req.status() : PropertyStatus.DRAFT);
+        property = propertyRepository.save(property);
+        log.info("Property created id={} tenant={}", property.getId(), tenantId);
+        return toResponse(property);
+    }
+
+    @Transactional
+    public PropertyResponse updateProperty(UUID id, UpdatePropertyRequest req) {
+        Property property = findOwnedProperty(id);
+        applyUpdate(property, req);
+        property = propertyRepository.save(property);
+        log.info("Property updated id={}", id);
+        return toResponse(property);
+    }
+
+    @Transactional
+    public void deleteProperty(UUID id) {
+        Property property = findOwnedProperty(id);
+        property.setDeletedAt(LocalDateTime.now());
+        propertyRepository.save(property);
+        log.info("Property soft-deleted id={}", id);
+    }
+
+    @Transactional(readOnly = true)
+    public PropertyResponse getProperty(UUID id) {
+        return toResponse(findOwnedProperty(id));
+    }
+
+    @Transactional(readOnly = true)
+    public Page<PropertySummaryResponse> listProperties(
+            PropertyStatus status,
+            PropertyOperation operation,
+            PropertyType propertyType,
+            BigDecimal minPrice,
+            BigDecimal maxPrice,
+            Integer bedrooms,
+            String city,
+            Pageable pageable) {
+        UUID tenantId = UUID.fromString(TenantContext.getTenantId());
+        return propertyRepository.findWithFilters(
+                tenantId, status, operation, propertyType, minPrice, maxPrice, bedrooms, city, pageable)
+                .map(this::toSummary);
+    }
+
+    // ── PHOTOS ────────────────────────────────────────────────────────────────
+
+    @Transactional
+    public PropertyPhotoResponse addPhoto(UUID propertyId, MultipartFile file, String altText) {
+        Property property = findOwnedProperty(propertyId);
+        FileStorageService.UploadResult result = fileStorageService.upload(file);
+
+        int nextPosition = photoRepository.countByPropertyId(propertyId);
+        boolean isFirstPhoto = nextPosition == 0;
+
+        PropertyPhoto photo = new PropertyPhoto();
+        photo.setProperty(property);
+        photo.setSeaweedFid(result.fid());
+        photo.setUrl(result.url());
+        photo.setPosition(nextPosition);
+        photo.setIsCover(isFirstPhoto);
+        photo.setAltText(altText);
+        photo = photoRepository.save(photo);
+
+        // First photo automatically becomes the cover
+        if (isFirstPhoto) {
+            property.setCoverPhotoId(photo.getId());
+            propertyRepository.save(property);
+        }
+
+        log.info("Photo added to property={} fid={}", propertyId, result.fid());
+        return toPhotoResponse(photo);
+    }
+
+    @Transactional
+    public void setCoverPhoto(UUID propertyId, UUID photoId) {
+        Property property = findOwnedProperty(propertyId);
+
+        // Clear current cover
+        List<PropertyPhoto> photos = photoRepository.findByPropertyIdOrderByPositionAsc(propertyId);
+        photos.forEach(p -> p.setIsCover(false));
+        photoRepository.saveAll(photos);
+
+        // Set new cover
+        PropertyPhoto coverPhoto = photos.stream()
+                .filter(p -> p.getId().equals(photoId))
+                .findFirst()
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Photo not found"));
+        coverPhoto.setIsCover(true);
+        photoRepository.save(coverPhoto);
+
+        property.setCoverPhotoId(photoId);
+        propertyRepository.save(property);
+        log.info("Cover photo set to={} on property={}", photoId, propertyId);
+    }
+
+    @Transactional
+    public void deletePhoto(UUID propertyId, UUID photoId) {
+        Property property = findOwnedProperty(propertyId);
+        PropertyPhoto photo = photoRepository.findByIdAndPropertyId(photoId, propertyId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Photo not found"));
+
+        boolean wasCover = Boolean.TRUE.equals(photo.getIsCover());
+        fileStorageService.delete(photo.getSeaweedFid(), photo.getUrl());
+        photoRepository.delete(photo);
+
+        if (wasCover) {
+            // Assign cover to the first remaining photo
+            photoRepository.findByPropertyIdOrderByPositionAsc(propertyId).stream()
+                    .findFirst()
+                    .ifPresentOrElse(next -> {
+                        next.setIsCover(true);
+                        photoRepository.save(next);
+                        property.setCoverPhotoId(next.getId());
+                    }, () -> property.setCoverPhotoId(null));
+            propertyRepository.save(property);
+        }
+        log.info("Photo deleted id={} from property={}", photoId, propertyId);
+    }
+
+    // ── FLOOR PLANS ──────────────────────────────────────────────────────────
+
+    @Transactional
+    public FloorPlanResponse addFloorPlan(UUID propertyId, CreateFloorPlanRequest req) {
+        Property property = findOwnedProperty(propertyId);
+        FloorPlan plan = new FloorPlan();
+        plan.setProperty(property);
+        plan.setName(req.name());
+        plan.setArea(req.area());
+        plan = floorPlanRepository.save(plan);
+        log.info("Floor plan added to property={} name={}", propertyId, req.name());
+        return toFloorPlanResponse(plan);
+    }
+
+    @Transactional
+    public void deleteFloorPlan(UUID propertyId, UUID planId) {
+        findOwnedProperty(propertyId);
+        FloorPlan plan = floorPlanRepository.findByIdAndPropertyId(planId, propertyId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Floor plan not found"));
+        // Delete all photos from SeaweedFS before removing the plan
+        plan.getPhotos().forEach(p -> fileStorageService.delete(p.getSeaweedFid(), p.getUrl()));
+        floorPlanRepository.delete(plan);
+        log.info("Floor plan deleted id={} from property={}", planId, propertyId);
+    }
+
+    @Transactional
+    public FloorPlanPhotoResponse addFloorPlanPhoto(UUID propertyId, UUID planId, MultipartFile file) {
+        findOwnedProperty(propertyId);
+        FloorPlan plan = floorPlanRepository.findByIdAndPropertyId(planId, propertyId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Floor plan not found"));
+
+        FileStorageService.UploadResult result = fileStorageService.upload(file);
+        int nextPosition = floorPlanPhotoRepository.countByFloorPlanId(planId);
+
+        FloorPlanPhoto photo = new FloorPlanPhoto();
+        photo.setFloorPlan(plan);
+        photo.setSeaweedFid(result.fid());
+        photo.setUrl(result.url());
+        photo.setPosition(nextPosition);
+        photo = floorPlanPhotoRepository.save(photo);
+        return toFloorPlanPhotoResponse(photo);
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private Property findOwnedProperty(UUID id) {
+        UUID tenantId = UUID.fromString(TenantContext.getTenantId());
+        return propertyRepository.findByIdAndTenantIdAndDeletedAtIsNull(id, tenantId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Property not found"));
+    }
+
+    private void applyRequest(Property p, CreatePropertyRequest req) {
+        p.setTitle(req.title());
+        p.setDescription(req.description());
+        p.setOperation(req.operation());
+        p.setPropertyType(req.propertyType());
+        p.setPrice(req.price());
+        p.setCurrency(req.currency() != null ? req.currency() : "BRL");
+        p.setTaxes(req.taxes());
+        p.setCondoFee(req.condoFee());
+        p.setAreaTotal(req.areaTotal());
+        p.setAreaUseful(req.areaUseful());
+        p.setBedrooms(req.bedrooms());
+        p.setSuites(req.suites());
+        p.setBathrooms(req.bathrooms());
+        p.setParking(req.parking());
+        p.setAddressStreet(req.addressStreet());
+        p.setAddressNumber(req.addressNumber());
+        p.setAddressComplement(req.addressComplement());
+        p.setAddressNeighborhood(req.addressNeighborhood());
+        p.setAddressCity(req.addressCity());
+        p.setAddressState(req.addressState());
+        p.setAddressCountry(req.addressCountry() != null ? req.addressCountry() : "BR");
+        p.setAddressZip(req.addressZip());
+        p.setLat(req.lat());
+        p.setLng(req.lng());
+        if (req.attributes() != null) p.setAttributes(req.attributes());
+    }
+
+    private void applyUpdate(Property p, UpdatePropertyRequest req) {
+        if (req.title() != null) p.setTitle(req.title());
+        if (req.description() != null) p.setDescription(req.description());
+        if (req.operation() != null) p.setOperation(req.operation());
+        if (req.propertyType() != null) p.setPropertyType(req.propertyType());
+        if (req.status() != null) {
+            p.setStatus(req.status());
+            if (req.status() == PropertyStatus.ACTIVE && p.getPublishedAt() == null) {
+                p.setPublishedAt(LocalDateTime.now());
+            }
+        }
+        if (req.price() != null) p.setPrice(req.price());
+        if (req.currency() != null) p.setCurrency(req.currency());
+        if (req.taxes() != null) p.setTaxes(req.taxes());
+        if (req.condoFee() != null) p.setCondoFee(req.condoFee());
+        if (req.areaTotal() != null) p.setAreaTotal(req.areaTotal());
+        if (req.areaUseful() != null) p.setAreaUseful(req.areaUseful());
+        if (req.bedrooms() != null) p.setBedrooms(req.bedrooms());
+        if (req.suites() != null) p.setSuites(req.suites());
+        if (req.bathrooms() != null) p.setBathrooms(req.bathrooms());
+        if (req.parking() != null) p.setParking(req.parking());
+        if (req.addressStreet() != null) p.setAddressStreet(req.addressStreet());
+        if (req.addressNumber() != null) p.setAddressNumber(req.addressNumber());
+        if (req.addressComplement() != null) p.setAddressComplement(req.addressComplement());
+        if (req.addressNeighborhood() != null) p.setAddressNeighborhood(req.addressNeighborhood());
+        if (req.addressCity() != null) p.setAddressCity(req.addressCity());
+        if (req.addressState() != null) p.setAddressState(req.addressState());
+        if (req.addressCountry() != null) p.setAddressCountry(req.addressCountry());
+        if (req.addressZip() != null) p.setAddressZip(req.addressZip());
+        if (req.lat() != null) p.setLat(req.lat());
+        if (req.lng() != null) p.setLng(req.lng());
+        if (req.attributes() != null) p.setAttributes(req.attributes());
+    }
+
+    private PropertyResponse toResponse(Property p) {
+        return new PropertyResponse(
+                p.getId(), p.getTitle(), p.getDescription(),
+                p.getOperation(), p.getPropertyType(), p.getStatus(),
+                p.getPrice(), p.getCurrency(), p.getTaxes(), p.getCondoFee(),
+                p.getAreaTotal(), p.getAreaUseful(),
+                p.getBedrooms(), p.getSuites(), p.getBathrooms(), p.getParking(),
+                p.getAddressStreet(), p.getAddressNumber(), p.getAddressComplement(),
+                p.getAddressNeighborhood(), p.getAddressCity(), p.getAddressState(),
+                p.getAddressCountry(), p.getAddressZip(),
+                p.getLat(), p.getLng(), p.getCoverPhotoId(),
+                p.getAttributes(), p.getPublishedAt(), p.getCreatedAt(), p.getUpdatedAt(),
+                p.getPhotos().stream().map(this::toPhotoResponse).toList(),
+                p.getFloorPlans().stream().map(this::toFloorPlanResponse).toList()
+        );
+    }
+
+    private PropertySummaryResponse toSummary(Property p) {
+        String coverUrl = p.getPhotos().stream()
+                .filter(ph -> Boolean.TRUE.equals(ph.getIsCover()))
+                .findFirst()
+                .map(PropertyPhoto::getUrl)
+                .orElse(null);
+        return new PropertySummaryResponse(
+                p.getId(), p.getTitle(), p.getOperation(), p.getPropertyType(), p.getStatus(),
+                p.getPrice(), p.getCurrency(), p.getAreaTotal(), p.getBedrooms(), p.getBathrooms(),
+                p.getAddressCity(), p.getAddressState(), p.getAddressCountry(),
+                p.getCoverPhotoId(), coverUrl, p.getCreatedAt()
+        );
+    }
+
+    private PropertyPhotoResponse toPhotoResponse(PropertyPhoto ph) {
+        return new PropertyPhotoResponse(ph.getId(), ph.getUrl(), ph.getPosition(),
+                ph.getIsCover(), ph.getAltText(), ph.getCreatedAt());
+    }
+
+    private FloorPlanResponse toFloorPlanResponse(FloorPlan fp) {
+        return new FloorPlanResponse(fp.getId(), fp.getName(), fp.getArea(), fp.getCreatedAt(),
+                fp.getPhotos().stream().map(this::toFloorPlanPhotoResponse).toList());
+    }
+
+    private FloorPlanPhotoResponse toFloorPlanPhotoResponse(FloorPlanPhoto fpp) {
+        return new FloorPlanPhotoResponse(fpp.getId(), fpp.getUrl(), fpp.getPosition(), fpp.getCreatedAt());
+    }
+}

--- a/src/main/java/com/rinoimob/service/auth/AuthService.java
+++ b/src/main/java/com/rinoimob/service/auth/AuthService.java
@@ -5,6 +5,7 @@ import com.rinoimob.domain.dto.IdentifyRequest;
 import com.rinoimob.domain.dto.IdentifyResponse;
 import com.rinoimob.domain.dto.LoginRequest;
 import com.rinoimob.domain.dto.LoginResponse;
+import com.rinoimob.domain.dto.MeResponse;
 import com.rinoimob.domain.dto.RegisterRequest;
 import com.rinoimob.domain.dto.SelectTenantRequest;
 import com.rinoimob.domain.dto.TenantRegistrationRequest;
@@ -20,6 +21,7 @@ import com.rinoimob.domain.repository.GlobalCredentialRepository;
 import com.rinoimob.domain.repository.TenantRepository;
 import com.rinoimob.domain.repository.UserRepository;
 import com.rinoimob.domain.repository.VerificationTokenRepository;
+import com.rinoimob.context.TenantContext;
 import com.rinoimob.service.email.EmailService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -346,6 +348,41 @@ public class AuthService {
         tokenRepository.delete(resetToken);
 
         log.info("Password reset for: {}", user.getEmail());
+    }
+
+    public MeResponse getMe(UUID userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+
+        String tenantIdStr = TenantContext.getTenantId();
+        UUID tenantId = null;
+        String tenantName = null;
+        String tenantSubdomain = null;
+
+        if (tenantIdStr != null) {
+            try {
+                tenantId = UUID.fromString(tenantIdStr);
+                Optional<Tenant> tenant = tenantRepository.findById(tenantId);
+                if (tenant.isPresent()) {
+                    tenantName = tenant.get().getName();
+                    tenantSubdomain = tenant.get().getSubdomain();
+                }
+            } catch (IllegalArgumentException ignored) {
+                // invalid UUID in context — skip tenant info
+            }
+        }
+
+        return new MeResponse(
+                user.getId(),
+                user.getEmail(),
+                user.getFirstName(),
+                user.getLastName(),
+                user.getActive(),
+                user.getCreatedAt(),
+                tenantId,
+                tenantName,
+                tenantSubdomain
+        );
     }
 
     public UserDto getUserProfile(UUID userId) {

--- a/src/main/java/com/rinoimob/service/storage/FileStorageService.java
+++ b/src/main/java/com/rinoimob/service/storage/FileStorageService.java
@@ -1,0 +1,87 @@
+package com.rinoimob.service.storage;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.Map;
+
+@Service
+@Slf4j
+public class FileStorageService {
+
+    private final RestTemplate restTemplate;
+    private final String masterUrl;
+
+    public FileStorageService(
+            RestTemplate restTemplate,
+            @Value("${seaweedfs.master.url:http://localhost:9333}") String masterUrl) {
+        this.restTemplate = restTemplate;
+        this.masterUrl = masterUrl;
+    }
+
+    public UploadResult upload(MultipartFile file) {
+        AssignResult assign = assign();
+        String uploadUrl = "http://" + assign.url() + "/" + assign.fid();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.MULTIPART_FORM_DATA);
+
+        MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
+        try {
+            body.add("file", new MultipartFileResource(file));
+        } catch (IOException e) {
+            throw new FileStorageException("Failed to read upload file: " + e.getMessage(), e);
+        }
+
+        HttpEntity<MultiValueMap<String, Object>> request = new HttpEntity<>(body, headers);
+        restTemplate.put(uploadUrl, request);
+
+        log.debug("Uploaded file to SeaweedFS fid={} url={}", assign.fid(), uploadUrl);
+        return new UploadResult(assign.fid(), uploadUrl);
+    }
+
+    public void delete(String seaweedFid, String url) {
+        try {
+            restTemplate.delete(url);
+            log.debug("Deleted file from SeaweedFS fid={}", seaweedFid);
+        } catch (Exception e) {
+            // Log but don't fail — the DB record will still be deleted
+            log.warn("Failed to delete file from SeaweedFS fid={}: {}", seaweedFid, e.getMessage());
+        }
+    }
+
+    private AssignResult assign() {
+        @SuppressWarnings("unchecked")
+        Map<String, Object> response = restTemplate.getForObject(
+                masterUrl + "/dir/assign", Map.class);
+
+        if (response == null || !response.containsKey("fid")) {
+            throw new FileStorageException("SeaweedFS assign returned no fid");
+        }
+
+        String fid = (String) response.get("fid");
+        String url = (String) response.get("url");
+        return new AssignResult(fid, url);
+    }
+
+    public record AssignResult(String fid, String url) {}
+    public record UploadResult(String fid, String url) {}
+
+    public static class FileStorageException extends RuntimeException {
+        public FileStorageException(String message) {
+            super(message);
+        }
+        public FileStorageException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+}

--- a/src/main/java/com/rinoimob/service/storage/FileStorageService.java
+++ b/src/main/java/com/rinoimob/service/storage/FileStorageService.java
@@ -2,9 +2,7 @@ package com.rinoimob.service.storage;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
+import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
@@ -20,17 +18,23 @@ public class FileStorageService {
 
     private final RestTemplate restTemplate;
     private final String masterUrl;
+    private final String volumePublicUrl;
 
     public FileStorageService(
             RestTemplate restTemplate,
-            @Value("${seaweedfs.master.url:http://localhost:9333}") String masterUrl) {
+            @Value("${seaweedfs.master.url:http://localhost:9333}") String masterUrl,
+            @Value("${seaweedfs.volume.public-url:http://localhost:8080}") String volumePublicUrl) {
         this.restTemplate = restTemplate;
         this.masterUrl = masterUrl;
+        this.volumePublicUrl = volumePublicUrl;
     }
 
     public UploadResult upload(MultipartFile file) {
         AssignResult assign = assign();
+
+        // Upload URL uses internal address (Docker network); public URL is used for serving.
         String uploadUrl = "http://" + assign.url() + "/" + assign.fid();
+        String publicUrl = volumePublicUrl + "/" + assign.fid();
 
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.MULTIPART_FORM_DATA);
@@ -42,19 +46,22 @@ public class FileStorageService {
             throw new FileStorageException("Failed to read upload file: " + e.getMessage(), e);
         }
 
+        // SeaweedFS requires POST for multipart/form-data uploads.
+        // PUT expects raw bytes; sending multipart via PUT corrupts the stored file.
         HttpEntity<MultiValueMap<String, Object>> request = new HttpEntity<>(body, headers);
-        restTemplate.put(uploadUrl, request);
+        restTemplate.exchange(uploadUrl, HttpMethod.POST, request, String.class);
 
-        log.debug("Uploaded file to SeaweedFS fid={} url={}", assign.fid(), uploadUrl);
-        return new UploadResult(assign.fid(), uploadUrl);
+        log.debug("Uploaded file to SeaweedFS fid={} url={}", assign.fid(), publicUrl);
+        return new UploadResult(assign.fid(), publicUrl);
     }
 
     public void delete(String seaweedFid, String url) {
         try {
-            restTemplate.delete(url);
+            // Resolve deletion via internal URL derived from fid
+            String internalUrl = resolveInternalUrl(url, seaweedFid);
+            restTemplate.delete(internalUrl);
             log.debug("Deleted file from SeaweedFS fid={}", seaweedFid);
         } catch (Exception e) {
-            // Log but don't fail — the DB record will still be deleted
             log.warn("Failed to delete file from SeaweedFS fid={}: {}", seaweedFid, e.getMessage());
         }
     }
@@ -73,15 +80,38 @@ public class FileStorageService {
         return new AssignResult(fid, url);
     }
 
+    /**
+     * Builds internal deletion URL. Stored URLs use the public base URL,
+     * so we reconstruct the internal address from the master assign result.
+     * If the volume server is local (url == publicUrl host), use it directly.
+     */
+    private String resolveInternalUrl(String storedUrl, String fid) {
+        // Strip the public base and reattach to internal master-assigned URL.
+        // Simplest: just re-assign to get a fresh volume url for the same fid via lookup.
+        // SeaweedFS supports DELETE directly on the volume node.
+        // We lookup the fid location via the master.
+        @SuppressWarnings("unchecked")
+        Map<String, Object> lookup = restTemplate.getForObject(
+                masterUrl + "/dir/lookup?volumeId=" + fid.split(",")[0], Map.class);
+        if (lookup != null && lookup.containsKey("locations")) {
+            @SuppressWarnings("unchecked")
+            java.util.List<Map<String, Object>> locations =
+                    (java.util.List<Map<String, Object>>) lookup.get("locations");
+            if (!locations.isEmpty()) {
+                String internalHost = (String) locations.get(0).get("url");
+                return "http://" + internalHost + "/" + fid;
+            }
+        }
+        // Fallback: swap public base with internal equivalent
+        return storedUrl.replace(volumePublicUrl, masterUrl.replace("9333", "8080"));
+    }
+
     public record AssignResult(String fid, String url) {}
     public record UploadResult(String fid, String url) {}
 
     public static class FileStorageException extends RuntimeException {
-        public FileStorageException(String message) {
-            super(message);
-        }
-        public FileStorageException(String message, Throwable cause) {
-            super(message, cause);
-        }
+        public FileStorageException(String message) { super(message); }
+        public FileStorageException(String message, Throwable cause) { super(message, cause); }
     }
 }
+

--- a/src/main/java/com/rinoimob/service/storage/MultipartFileResource.java
+++ b/src/main/java/com/rinoimob/service/storage/MultipartFileResource.java
@@ -1,0 +1,22 @@
+package com.rinoimob.service.storage;
+
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+/** Wraps a MultipartFile as a Spring Resource so RestTemplate can send it as multipart. */
+class MultipartFileResource extends ByteArrayResource {
+
+    private final String filename;
+
+    MultipartFileResource(MultipartFile file) throws IOException {
+        super(file.getBytes());
+        this.filename = file.getOriginalFilename();
+    }
+
+    @Override
+    public String getFilename() {
+        return filename;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -60,3 +60,5 @@ app:
 seaweedfs:
   master:
     url: ${SEAWEEDFS_MASTER_URL:http://localhost:9333}
+  volume:
+    public-url: ${SEAWEEDFS_VOLUME_PUBLIC_URL:http://localhost:8080}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -56,3 +56,7 @@ app:
     allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:5173,http://127.0.0.1:5173,http://localhost:3000,http://127.0.0.1:3000}
   verification-token-expiration: ${VERIFICATION_TOKEN_EXPIRATION:86400}
   reset-token-expiration: ${RESET_TOKEN_EXPIRATION:3600}
+
+seaweedfs:
+  master:
+    url: ${SEAWEEDFS_MASTER_URL:http://localhost:9333}

--- a/src/main/resources/db/migration/V4__property_schema.sql
+++ b/src/main/resources/db/migration/V4__property_schema.sql
@@ -1,0 +1,82 @@
+-- V4__property_schema.sql
+-- Replace Phase 0 placeholder properties table with full spec.
+-- Add property_photos, floor_plans, floor_plan_photos.
+
+DROP TABLE IF EXISTS properties CASCADE;
+
+CREATE TABLE properties (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    title VARCHAR(200) NOT NULL,
+    description TEXT,
+    operation VARCHAR(20) NOT NULL,
+    property_type VARCHAR(20) NOT NULL,
+    status VARCHAR(20) NOT NULL DEFAULT 'DRAFT',
+    price NUMERIC(14,2),
+    currency VARCHAR(3) NOT NULL DEFAULT 'BRL',
+    taxes NUMERIC(14,2),
+    condo_fee NUMERIC(14,2),
+    area_total NUMERIC(10,2),
+    area_useful NUMERIC(10,2),
+    bedrooms INT,
+    suites INT,
+    bathrooms INT,
+    parking INT,
+    address_street VARCHAR(255),
+    address_number VARCHAR(20),
+    address_complement VARCHAR(100),
+    address_neighborhood VARCHAR(100),
+    address_city VARCHAR(100),
+    address_state VARCHAR(100),
+    address_country VARCHAR(2) NOT NULL DEFAULT 'BR',
+    address_zip VARCHAR(20),
+    lat NUMERIC(10,7),
+    lng NUMERIC(10,7),
+    cover_photo_id UUID,
+    attributes JSONB NOT NULL DEFAULT '{}',
+    published_at TIMESTAMP,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    deleted_at TIMESTAMP
+);
+
+CREATE INDEX idx_properties_tenant_id ON properties(tenant_id);
+CREATE INDEX idx_properties_status ON properties(status);
+CREATE INDEX idx_properties_operation ON properties(operation);
+CREATE INDEX idx_properties_property_type ON properties(property_type);
+CREATE INDEX idx_properties_address_city ON properties(address_city);
+CREATE INDEX idx_properties_deleted_at ON properties(deleted_at);
+
+CREATE TABLE property_photos (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    property_id UUID NOT NULL REFERENCES properties(id) ON DELETE CASCADE,
+    seaweed_fid VARCHAR(100) NOT NULL,
+    url TEXT NOT NULL,
+    position INT NOT NULL DEFAULT 0,
+    is_cover BOOLEAN NOT NULL DEFAULT FALSE,
+    alt_text VARCHAR(255),
+    created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_property_photos_property_id ON property_photos(property_id);
+
+CREATE TABLE floor_plans (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    property_id UUID NOT NULL REFERENCES properties(id) ON DELETE CASCADE,
+    name VARCHAR(100) NOT NULL,
+    area NUMERIC(10,2),
+    created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_floor_plans_property_id ON floor_plans(property_id);
+
+CREATE TABLE floor_plan_photos (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    floor_plan_id UUID NOT NULL REFERENCES floor_plans(id) ON DELETE CASCADE,
+    seaweed_fid VARCHAR(100) NOT NULL,
+    url TEXT NOT NULL,
+    position INT NOT NULL DEFAULT 0,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_floor_plan_photos_floor_plan_id ON floor_plan_photos(floor_plan_id);

--- a/src/main/resources/db/migration/V5__categories_and_property_enhancements.sql
+++ b/src/main/resources/db/migration/V5__categories_and_property_enhancements.sql
@@ -1,0 +1,40 @@
+-- V5: Categories, property enhancements (reference code, floor number, condition)
+
+-- Categories table (tenant_id NULL = global/system category)
+CREATE TABLE property_categories (
+    id        UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id UUID REFERENCES tenants(id) ON DELETE CASCADE,
+    name      VARCHAR(100) NOT NULL,
+    slug      VARCHAR(100) NOT NULL,
+    color     VARCHAR(7),
+    active    BOOLEAN NOT NULL DEFAULT TRUE,
+    position  INT NOT NULL DEFAULT 0,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    CONSTRAINT uq_category_slug_tenant UNIQUE (tenant_id, slug)
+);
+
+-- Global categories can't use the same constraint (tenant_id is NULL); enforce via partial index
+CREATE UNIQUE INDEX uq_global_category_slug ON property_categories (slug) WHERE tenant_id IS NULL;
+
+-- Junction: property ↔ category (many-to-many)
+CREATE TABLE property_category_map (
+    property_id UUID NOT NULL REFERENCES properties(id) ON DELETE CASCADE,
+    category_id UUID NOT NULL REFERENCES property_categories(id) ON DELETE CASCADE,
+    PRIMARY KEY (property_id, category_id)
+);
+
+-- Property enhancements
+ALTER TABLE properties
+    ADD COLUMN reference_code VARCHAR(50),
+    ADD COLUMN floor_number   INT,
+    ADD COLUMN condition      VARCHAR(30);
+
+-- Create index for reference_code lookups per tenant
+CREATE INDEX idx_properties_reference_code ON properties (tenant_id, reference_code) WHERE reference_code IS NOT NULL;
+
+-- Seed global categories
+INSERT INTO property_categories (id, tenant_id, name, slug, color, position) VALUES
+    ('00000000-0000-0000-0000-000000000001', NULL, 'Lançamentos',  'lancamentos',  '#10b981', 1),
+    ('00000000-0000-0000-0000-000000000002', NULL, 'Avulsos',      'avulsos',      '#6366f1', 2),
+    ('00000000-0000-0000-0000-000000000003', NULL, 'Leilão',       'leilao',       '#f59e0b', 3);

--- a/src/test/java/com/rinoimob/service/PropertyServiceTest.java
+++ b/src/test/java/com/rinoimob/service/PropertyServiceTest.java
@@ -1,0 +1,358 @@
+package com.rinoimob.service;
+
+import com.rinoimob.context.TenantContext;
+import com.rinoimob.domain.dto.property.*;
+import com.rinoimob.domain.entity.FloorPlan;
+import com.rinoimob.domain.entity.Property;
+import com.rinoimob.domain.entity.PropertyPhoto;
+import com.rinoimob.domain.enums.PropertyOperation;
+import com.rinoimob.domain.enums.PropertyStatus;
+import com.rinoimob.domain.enums.PropertyType;
+import com.rinoimob.domain.repository.*;
+import com.rinoimob.service.storage.FileStorageService;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PropertyServiceTest {
+
+    private static final UUID TENANT_ID = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static final UUID PROPERTY_ID = UUID.fromString("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+    private static final UUID PHOTO_ID = UUID.fromString("cccccccc-cccc-cccc-cccc-cccccccccccc");
+    private static final UUID FLOOR_PLAN_ID = UUID.fromString("dddddddd-dddd-dddd-dddd-dddddddddddd");
+
+    @Mock private PropertyRepository propertyRepository;
+    @Mock private PropertyPhotoRepository photoRepository;
+    @Mock private FloorPlanRepository floorPlanRepository;
+    @Mock private FloorPlanPhotoRepository floorPlanPhotoRepository;
+    @Mock private FileStorageService fileStorageService;
+
+    private PropertyService propertyService;
+
+    @BeforeEach
+    void setUp() {
+        TenantContext.setTenantId(TENANT_ID.toString());
+        propertyService = new PropertyService(
+                propertyRepository, photoRepository, floorPlanRepository,
+                floorPlanPhotoRepository, fileStorageService);
+    }
+
+    @AfterEach
+    void tearDown() {
+        TenantContext.clear();
+    }
+
+    // ── createProperty ────────────────────────────────────────────────────────
+
+    @Test
+    void createProperty_savesAndReturnsMappedResponse() {
+        CreatePropertyRequest req = new CreatePropertyRequest(
+                "Casa Teste", "Descrição", PropertyOperation.SALE, PropertyType.HOUSE,
+                PropertyStatus.DRAFT, new BigDecimal("500000"), "BRL", null, null,
+                new BigDecimal("120"), new BigDecimal("100"), 3, 1, 2, 2,
+                "Rua A", "10", null, "Bairro", "São Paulo", "SP", "BR", "01001-000",
+                null, null, null);
+
+        Property savedProperty = buildProperty();
+        when(propertyRepository.save(any(Property.class))).thenReturn(savedProperty);
+
+        PropertyResponse response = propertyService.createProperty(req);
+
+        assertThat(response).isNotNull();
+        assertThat(response.id()).isEqualTo(PROPERTY_ID);
+        assertThat(response.title()).isEqualTo("Casa Teste");
+        verify(propertyRepository).save(any(Property.class));
+    }
+
+    @Test
+    void createProperty_defaultsToDraftStatus_whenStatusNull() {
+        CreatePropertyRequest req = new CreatePropertyRequest(
+                "Casa", null, PropertyOperation.RENT, PropertyType.APARTMENT,
+                null, null, null, null, null, null, null, null, null, null, null,
+                null, null, null, null, null, null, null, null, null, null, null);
+
+        Property savedProperty = buildProperty();
+        when(propertyRepository.save(any(Property.class))).thenReturn(savedProperty);
+
+        propertyService.createProperty(req);
+
+        ArgumentCaptor<Property> captor = ArgumentCaptor.forClass(Property.class);
+        verify(propertyRepository).save(captor.capture());
+        assertThat(captor.getValue().getStatus()).isEqualTo(PropertyStatus.DRAFT);
+    }
+
+    // ── getProperty ───────────────────────────────────────────────────────────
+
+    @Test
+    void getProperty_returnsResponse_whenFound() {
+        when(propertyRepository.findByIdAndTenantIdAndDeletedAtIsNull(PROPERTY_ID, TENANT_ID))
+                .thenReturn(Optional.of(buildProperty()));
+
+        PropertyResponse response = propertyService.getProperty(PROPERTY_ID);
+
+        assertThat(response.id()).isEqualTo(PROPERTY_ID);
+    }
+
+    @Test
+    void getProperty_throws404_whenNotFound() {
+        when(propertyRepository.findByIdAndTenantIdAndDeletedAtIsNull(PROPERTY_ID, TENANT_ID))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> propertyService.getProperty(PROPERTY_ID))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("Property not found");
+    }
+
+    // ── updateProperty ────────────────────────────────────────────────────────
+
+    @Test
+    void updateProperty_updatesOnlyProvidedFields() {
+        Property existing = buildProperty();
+        when(propertyRepository.findByIdAndTenantIdAndDeletedAtIsNull(PROPERTY_ID, TENANT_ID))
+                .thenReturn(Optional.of(existing));
+        when(propertyRepository.save(any(Property.class))).thenReturn(existing);
+
+        UpdatePropertyRequest req = new UpdatePropertyRequest(
+                "Novo Título", null, null, null, null, null, null, null, null,
+                null, null, null, null, null, null,
+                null, null, null, null, null, null, null, null, null, null, null);
+
+        PropertyResponse response = propertyService.updateProperty(PROPERTY_ID, req);
+
+        assertThat(response).isNotNull();
+        assertThat(existing.getTitle()).isEqualTo("Novo Título");
+        verify(propertyRepository).save(existing);
+    }
+
+    @Test
+    void updateProperty_setsPublishedAt_whenStatusChangesToActive() {
+        Property existing = buildProperty();
+        existing.setPublishedAt(null);
+        when(propertyRepository.findByIdAndTenantIdAndDeletedAtIsNull(PROPERTY_ID, TENANT_ID))
+                .thenReturn(Optional.of(existing));
+        when(propertyRepository.save(any(Property.class))).thenReturn(existing);
+
+        UpdatePropertyRequest req = new UpdatePropertyRequest(
+                null, null, null, null, PropertyStatus.ACTIVE, null, null, null, null,
+                null, null, null, null, null, null,
+                null, null, null, null, null, null, null, null, null, null, null);
+
+        propertyService.updateProperty(PROPERTY_ID, req);
+
+        assertThat(existing.getPublishedAt()).isNotNull();
+    }
+
+    // ── deleteProperty ────────────────────────────────────────────────────────
+
+    @Test
+    void deleteProperty_setsDeletedAt() {
+        Property existing = buildProperty();
+        when(propertyRepository.findByIdAndTenantIdAndDeletedAtIsNull(PROPERTY_ID, TENANT_ID))
+                .thenReturn(Optional.of(existing));
+        when(propertyRepository.save(any(Property.class))).thenReturn(existing);
+
+        propertyService.deleteProperty(PROPERTY_ID);
+
+        assertThat(existing.getDeletedAt()).isNotNull();
+        verify(propertyRepository).save(existing);
+    }
+
+    // ── listProperties ────────────────────────────────────────────────────────
+
+    @Test
+    void listProperties_returnsMappedPage() {
+        Page<Property> page = new PageImpl<>(List.of(buildProperty()));
+        when(propertyRepository.findWithFilters(
+                eq(TENANT_ID), any(), any(), any(), any(), any(), any(), any(), any()))
+                .thenReturn(page);
+
+        Page<PropertySummaryResponse> result = propertyService.listProperties(
+                null, null, null, null, null, null, null, PageRequest.of(0, 20));
+
+        assertThat(result.getTotalElements()).isEqualTo(1);
+    }
+
+    // ── tenantIsolation ───────────────────────────────────────────────────────
+
+    @Test
+    void tenantIsolation_alwaysPassesTenantIdFromContext() {
+        UUID otherTenant = UUID.randomUUID();
+        TenantContext.setTenantId(otherTenant.toString());
+
+        when(propertyRepository.findByIdAndTenantIdAndDeletedAtIsNull(PROPERTY_ID, otherTenant))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> propertyService.getProperty(PROPERTY_ID))
+                .isInstanceOf(ResponseStatusException.class);
+
+        verify(propertyRepository).findByIdAndTenantIdAndDeletedAtIsNull(PROPERTY_ID, otherTenant);
+        verify(propertyRepository, never()).findByIdAndTenantIdAndDeletedAtIsNull(PROPERTY_ID, TENANT_ID);
+    }
+
+    // ── addPhoto ──────────────────────────────────────────────────────────────
+
+    @Test
+    void addPhoto_firstPhotoBecomesAutoCover() {
+        Property property = buildProperty();
+        when(propertyRepository.findByIdAndTenantIdAndDeletedAtIsNull(PROPERTY_ID, TENANT_ID))
+                .thenReturn(Optional.of(property));
+        when(photoRepository.countByPropertyId(PROPERTY_ID)).thenReturn(0);
+        when(fileStorageService.upload(any()))
+                .thenReturn(new FileStorageService.UploadResult("1,01", "http://storage/1,01"));
+        PropertyPhoto savedPhoto = buildPhoto(property, true);
+        when(photoRepository.save(any())).thenReturn(savedPhoto);
+        when(propertyRepository.save(any())).thenReturn(property);
+
+        MockMultipartFile file = new MockMultipartFile("file", "photo.jpg", "image/jpeg", new byte[100]);
+        PropertyPhotoResponse response = propertyService.addPhoto(PROPERTY_ID, file, "alt text");
+
+        assertThat(response.isCover()).isTrue();
+        verify(propertyRepository).save(argThat(p -> PHOTO_ID.equals(p.getCoverPhotoId())));
+    }
+
+    @Test
+    void addPhoto_secondPhotoNotCover() {
+        Property property = buildProperty();
+        when(propertyRepository.findByIdAndTenantIdAndDeletedAtIsNull(PROPERTY_ID, TENANT_ID))
+                .thenReturn(Optional.of(property));
+        when(photoRepository.countByPropertyId(PROPERTY_ID)).thenReturn(1);
+        when(fileStorageService.upload(any()))
+                .thenReturn(new FileStorageService.UploadResult("1,02", "http://storage/1,02"));
+        PropertyPhoto savedPhoto = buildPhoto(property, false);
+        when(photoRepository.save(any())).thenReturn(savedPhoto);
+
+        MockMultipartFile file = new MockMultipartFile("file", "photo2.jpg", "image/jpeg", new byte[100]);
+        PropertyPhotoResponse response = propertyService.addPhoto(PROPERTY_ID, file, null);
+
+        assertThat(response.isCover()).isFalse();
+        verify(propertyRepository, never()).save(any());
+    }
+
+    // ── setCoverPhoto ─────────────────────────────────────────────────────────
+
+    @Test
+    void setCoverPhoto_updatesIsCoverAndProperty() {
+        Property property = buildProperty();
+        PropertyPhoto photo = buildPhoto(property, false);
+        when(propertyRepository.findByIdAndTenantIdAndDeletedAtIsNull(PROPERTY_ID, TENANT_ID))
+                .thenReturn(Optional.of(property));
+        when(photoRepository.findByPropertyIdOrderByPositionAsc(PROPERTY_ID))
+                .thenReturn(List.of(photo));
+
+        propertyService.setCoverPhoto(PROPERTY_ID, PHOTO_ID);
+
+        assertThat(photo.getIsCover()).isTrue();
+        verify(propertyRepository).save(argThat(p -> PHOTO_ID.equals(p.getCoverPhotoId())));
+    }
+
+    // ── deletePhoto ───────────────────────────────────────────────────────────
+
+    @Test
+    void deletePhoto_deletesFromStorageAndRepo() {
+        Property property = buildProperty();
+        PropertyPhoto photo = buildPhoto(property, false);
+        when(propertyRepository.findByIdAndTenantIdAndDeletedAtIsNull(PROPERTY_ID, TENANT_ID))
+                .thenReturn(Optional.of(property));
+        when(photoRepository.findByIdAndPropertyId(PHOTO_ID, PROPERTY_ID))
+                .thenReturn(Optional.of(photo));
+
+        propertyService.deletePhoto(PROPERTY_ID, PHOTO_ID);
+
+        verify(fileStorageService).delete("1,01", "http://storage/1,01");
+        verify(photoRepository).delete(photo);
+    }
+
+    @Test
+    void deletePhoto_whenCoverDeleted_promotesNextPhoto() {
+        Property property = buildProperty();
+        PropertyPhoto coverPhoto = buildPhoto(property, true);
+        UUID nextPhotoId = UUID.randomUUID();
+        PropertyPhoto nextPhoto = buildPhoto(property, false);
+        nextPhoto.setId(nextPhotoId);
+
+        when(propertyRepository.findByIdAndTenantIdAndDeletedAtIsNull(PROPERTY_ID, TENANT_ID))
+                .thenReturn(Optional.of(property));
+        when(photoRepository.findByIdAndPropertyId(PHOTO_ID, PROPERTY_ID))
+                .thenReturn(Optional.of(coverPhoto));
+        when(photoRepository.findByPropertyIdOrderByPositionAsc(PROPERTY_ID))
+                .thenReturn(List.of(nextPhoto));
+
+        propertyService.deletePhoto(PROPERTY_ID, PHOTO_ID);
+
+        assertThat(nextPhoto.getIsCover()).isTrue();
+        verify(propertyRepository).save(argThat(p -> nextPhotoId.equals(p.getCoverPhotoId())));
+    }
+
+    // ── addFloorPlan ──────────────────────────────────────────────────────────
+
+    @Test
+    void addFloorPlan_savesAndReturnsResponse() {
+        Property property = buildProperty();
+        when(propertyRepository.findByIdAndTenantIdAndDeletedAtIsNull(PROPERTY_ID, TENANT_ID))
+                .thenReturn(Optional.of(property));
+        FloorPlan plan = buildFloorPlan(property);
+        when(floorPlanRepository.save(any())).thenReturn(plan);
+
+        CreateFloorPlanRequest req = new CreateFloorPlanRequest("Térreo", new BigDecimal("80"));
+        FloorPlanResponse response = propertyService.addFloorPlan(PROPERTY_ID, req);
+
+        assertThat(response.id()).isEqualTo(FLOOR_PLAN_ID);
+        assertThat(response.name()).isEqualTo("Térreo");
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private Property buildProperty() {
+        Property p = new Property();
+        p.setId(PROPERTY_ID);
+        p.setTenantId(TENANT_ID);
+        p.setTitle("Casa Teste");
+        p.setOperation(PropertyOperation.SALE);
+        p.setPropertyType(PropertyType.HOUSE);
+        p.setStatus(PropertyStatus.DRAFT);
+        p.setCurrency("BRL");
+        p.setAddressCountry("BR");
+        p.setAttributes(new HashMap<>());
+        p.setCreatedAt(LocalDateTime.now());
+        p.setUpdatedAt(LocalDateTime.now());
+        return p;
+    }
+
+    private PropertyPhoto buildPhoto(Property property, boolean isCover) {
+        PropertyPhoto photo = new PropertyPhoto();
+        photo.setId(PHOTO_ID);
+        photo.setProperty(property);
+        photo.setSeaweedFid("1,01");
+        photo.setUrl("http://storage/1,01");
+        photo.setPosition(0);
+        photo.setIsCover(isCover);
+        photo.setCreatedAt(LocalDateTime.now());
+        return photo;
+    }
+
+    private FloorPlan buildFloorPlan(Property property) {
+        FloorPlan plan = new FloorPlan();
+        plan.setId(FLOOR_PLAN_ID);
+        plan.setProperty(property);
+        plan.setName("Térreo");
+        plan.setArea(new BigDecimal("80"));
+        plan.setCreatedAt(LocalDateTime.now());
+        plan.setPhotos(new ArrayList<>());
+        return plan;
+    }
+}

--- a/src/test/java/com/rinoimob/service/PropertyServiceTest.java
+++ b/src/test/java/com/rinoimob/service/PropertyServiceTest.java
@@ -177,8 +177,7 @@ class PropertyServiceTest {
     @Test
     void listProperties_returnsMappedPage() {
         Page<Property> page = new PageImpl<>(List.of(buildProperty()));
-        when(propertyRepository.findWithFilters(
-                eq(TENANT_ID), any(), any(), any(), any(), any(), any(), any(), any()))
+        when(propertyRepository.findAll(any(org.springframework.data.jpa.domain.Specification.class), any(org.springframework.data.domain.Pageable.class)))
                 .thenReturn(page);
 
         Page<PropertySummaryResponse> result = propertyService.listProperties(

--- a/src/test/java/com/rinoimob/service/PropertyServiceTest.java
+++ b/src/test/java/com/rinoimob/service/PropertyServiceTest.java
@@ -8,6 +8,7 @@ import com.rinoimob.domain.entity.PropertyPhoto;
 import com.rinoimob.domain.enums.PropertyOperation;
 import com.rinoimob.domain.enums.PropertyStatus;
 import com.rinoimob.domain.enums.PropertyType;
+import com.rinoimob.domain.enums.PropertyCondition;
 import com.rinoimob.domain.repository.*;
 import com.rinoimob.service.storage.FileStorageService;
 import org.junit.jupiter.api.*;
@@ -40,7 +41,9 @@ class PropertyServiceTest {
     @Mock private PropertyPhotoRepository photoRepository;
     @Mock private FloorPlanRepository floorPlanRepository;
     @Mock private FloorPlanPhotoRepository floorPlanPhotoRepository;
+    @Mock private PropertyCategoryRepository categoryRepository;
     @Mock private FileStorageService fileStorageService;
+    @Mock private CategoryService categoryService;
 
     private PropertyService propertyService;
 
@@ -49,7 +52,7 @@ class PropertyServiceTest {
         TenantContext.setTenantId(TENANT_ID.toString());
         propertyService = new PropertyService(
                 propertyRepository, photoRepository, floorPlanRepository,
-                floorPlanPhotoRepository, fileStorageService);
+                floorPlanPhotoRepository, categoryRepository, fileStorageService, categoryService);
     }
 
     @AfterEach
@@ -63,10 +66,10 @@ class PropertyServiceTest {
     void createProperty_savesAndReturnsMappedResponse() {
         CreatePropertyRequest req = new CreatePropertyRequest(
                 "Casa Teste", "Descrição", PropertyOperation.SALE, PropertyType.HOUSE,
-                PropertyStatus.DRAFT, new BigDecimal("500000"), "BRL", null, null,
-                new BigDecimal("120"), new BigDecimal("100"), 3, 1, 2, 2,
+                PropertyStatus.DRAFT, null, null, new BigDecimal("500000"), "BRL", null, null,
+                new BigDecimal("120"), new BigDecimal("100"), 3, 1, 2, 2, null,
                 "Rua A", "10", null, "Bairro", "São Paulo", "SP", "BR", "01001-000",
-                null, null, null);
+                null, null, null, null);
 
         Property savedProperty = buildProperty();
         when(propertyRepository.save(any(Property.class))).thenReturn(savedProperty);
@@ -83,8 +86,8 @@ class PropertyServiceTest {
     void createProperty_defaultsToDraftStatus_whenStatusNull() {
         CreatePropertyRequest req = new CreatePropertyRequest(
                 "Casa", null, PropertyOperation.RENT, PropertyType.APARTMENT,
-                null, null, null, null, null, null, null, null, null, null, null,
-                null, null, null, null, null, null, null, null, null, null, null);
+                null, null, null, null, null, null, null, null, null, null, null, null, null, null,
+                null, null, null, null, null, null, null, null, null, null, null, null);
 
         Property savedProperty = buildProperty();
         when(propertyRepository.save(any(Property.class))).thenReturn(savedProperty);
@@ -129,8 +132,8 @@ class PropertyServiceTest {
 
         UpdatePropertyRequest req = new UpdatePropertyRequest(
                 "Novo Título", null, null, null, null, null, null, null, null,
-                null, null, null, null, null, null,
-                null, null, null, null, null, null, null, null, null, null, null);
+                null, null, null, null, null, null, null, null, null,
+                null, null, null, null, null, null, null, null, null, null, null, null);
 
         PropertyResponse response = propertyService.updateProperty(PROPERTY_ID, req);
 
@@ -149,8 +152,8 @@ class PropertyServiceTest {
 
         UpdatePropertyRequest req = new UpdatePropertyRequest(
                 null, null, null, null, PropertyStatus.ACTIVE, null, null, null, null,
-                null, null, null, null, null, null,
-                null, null, null, null, null, null, null, null, null, null, null);
+                null, null, null, null, null, null, null, null, null,
+                null, null, null, null, null, null, null, null, null, null, null, null);
 
         propertyService.updateProperty(PROPERTY_ID, req);
 
@@ -327,6 +330,7 @@ class PropertyServiceTest {
         p.setCurrency("BRL");
         p.setAddressCountry("BR");
         p.setAttributes(new HashMap<>());
+        p.setCategories(new HashSet<>());
         p.setCreatedAt(LocalDateTime.now());
         p.setUpdatedAt(LocalDateTime.now());
         return p;


### PR DESCRIPTION
## What's in this PR

### Features
- **V5 migration** — `property_categories` + `property_category_map` tables, new columns on `properties`, seeded 3 global categories
- **Categories API** — `GET/POST /api/v1/categories`, `PUT/DELETE /api/v1/categories/{id}`; global categories protected from edit/delete
- **Property enhancements** — `condition` (enum), `referenceCode`, `floorNumber`, `attributes` JSONB, `categoryIds` ↔ `Set<PropertyCategory>`
- **`/me` endpoint** — `GET /api/v1/users/me` returns authenticated user data for session validation
- **`resolveCategories()`** in PropertyService — validates IDs belong to tenant or are global

### Fixes
- `lower(bytea)` PostgreSQL error — cast `address_city` to `text` before `lower()` in JPQL query
- Photo upload multipart handling fix
- `CategoryResponse.isGlobal` field rename

### Tests
- 86/86 tests passing

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>