### PR TITLE
Phase 3: CRM Leads module with Kanban, events, multi-property interest

### DIFF
--- a/src/main/java/com/rinoimob/api/controller/LeadController.java
+++ b/src/main/java/com/rinoimob/api/controller/LeadController.java
@@ -1,0 +1,70 @@
+package com.rinoimob.api.controller;
+
+import com.rinoimob.context.TenantContext;
+import com.rinoimob.domain.dto.*;
+import com.rinoimob.domain.enums.LeadStatus;
+import com.rinoimob.service.LeadService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/leads")
+@RequiredArgsConstructor
+public class LeadController {
+
+    private final LeadService leadService;
+
+    @GetMapping
+    public ResponseEntity<Page<LeadResponse>> list(
+            @RequestParam(required = false) LeadStatus status,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+        UUID tenantId = UUID.fromString(TenantContext.getTenantId());
+        return ResponseEntity.ok(leadService.list(tenantId, status, page, size));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<LeadResponse> get(@PathVariable UUID id) {
+        UUID tenantId = UUID.fromString(TenantContext.getTenantId());
+        return ResponseEntity.ok(leadService.get(tenantId, id));
+    }
+
+    @PostMapping
+    public ResponseEntity<LeadResponse> create(
+            @Valid @RequestBody CreateLeadRequest request) {
+        UUID tenantId = UUID.fromString(TenantContext.getTenantId());
+        return ResponseEntity.status(HttpStatus.CREATED).body(leadService.create(tenantId, request));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<LeadResponse> update(
+            @PathVariable UUID id,
+            @RequestBody UpdateLeadRequest request) {
+        UUID tenantId = UUID.fromString(TenantContext.getTenantId());
+        return ResponseEntity.ok(leadService.update(tenantId, id, request));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable UUID id) {
+        UUID tenantId = UUID.fromString(TenantContext.getTenantId());
+        leadService.delete(tenantId, id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/{id}/notes")
+    public ResponseEntity<LeadNoteResponse> addNote(
+            @PathVariable UUID id,
+            @Valid @RequestBody LeadNoteRequest request,
+            HttpServletRequest httpRequest) {
+        UUID tenantId = UUID.fromString(TenantContext.getTenantId());
+        UUID userId = (UUID) httpRequest.getAttribute("userId");
+        return ResponseEntity.status(HttpStatus.CREATED).body(leadService.addNote(tenantId, id, userId, request));
+    }
+}

--- a/src/main/java/com/rinoimob/api/controller/LeadController.java
+++ b/src/main/java/com/rinoimob/api/controller/LeadController.java
@@ -74,4 +74,30 @@ public class LeadController {
         UUID tenantId = UUID.fromString(TenantContext.getTenantId());
         return ResponseEntity.ok(leadService.getEvents(tenantId, id));
     }
+
+    @PostMapping("/{id}/properties")
+    public ResponseEntity<LeadPropertyResponse> addProperty(
+            @PathVariable UUID id,
+            @Valid @RequestBody AddLeadPropertyRequest request) {
+        UUID tenantId = UUID.fromString(TenantContext.getTenantId());
+        return ResponseEntity.status(HttpStatus.CREATED).body(leadService.addProperty(tenantId, id, request));
+    }
+
+    @PatchMapping("/{id}/properties/{linkId}")
+    public ResponseEntity<LeadPropertyResponse> updatePropertyInterest(
+            @PathVariable UUID id,
+            @PathVariable UUID linkId,
+            @Valid @RequestBody UpdateLeadPropertyRequest request) {
+        UUID tenantId = UUID.fromString(TenantContext.getTenantId());
+        return ResponseEntity.ok(leadService.updatePropertyInterest(tenantId, id, linkId, request));
+    }
+
+    @DeleteMapping("/{id}/properties/{linkId}")
+    public ResponseEntity<Void> removeProperty(
+            @PathVariable UUID id,
+            @PathVariable UUID linkId) {
+        UUID tenantId = UUID.fromString(TenantContext.getTenantId());
+        leadService.removeProperty(tenantId, id, linkId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/rinoimob/api/controller/LeadController.java
+++ b/src/main/java/com/rinoimob/api/controller/LeadController.java
@@ -75,6 +75,12 @@ public class LeadController {
         return ResponseEntity.ok(leadService.getEvents(tenantId, id));
     }
 
+    @GetMapping("/{id}/properties")
+    public ResponseEntity<List<LeadPropertyResponse>> getProperties(@PathVariable UUID id) {
+        UUID tenantId = UUID.fromString(TenantContext.getTenantId());
+        return ResponseEntity.ok(leadService.getProperties(tenantId, id));
+    }
+
     @PostMapping("/{id}/properties")
     public ResponseEntity<LeadPropertyResponse> addProperty(
             @PathVariable UUID id,

--- a/src/main/java/com/rinoimob/api/controller/LeadController.java
+++ b/src/main/java/com/rinoimob/api/controller/LeadController.java
@@ -22,6 +22,12 @@ public class LeadController {
 
     private final LeadService leadService;
 
+    @GetMapping("/stats")
+    public LeadStatsResponse stats() {
+        UUID tenantId = UUID.fromString(TenantContext.getTenantId());
+        return leadService.getStats(tenantId);
+    }
+
     @GetMapping
     public ResponseEntity<Page<LeadResponse>> list(
             @RequestParam(required = false) LeadStatus status,

--- a/src/main/java/com/rinoimob/api/controller/LeadController.java
+++ b/src/main/java/com/rinoimob/api/controller/LeadController.java
@@ -12,6 +12,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.UUID;
 
 @RestController
@@ -66,5 +67,11 @@ public class LeadController {
         UUID tenantId = UUID.fromString(TenantContext.getTenantId());
         UUID userId = (UUID) httpRequest.getAttribute("userId");
         return ResponseEntity.status(HttpStatus.CREATED).body(leadService.addNote(tenantId, id, userId, request));
+    }
+
+    @GetMapping("/{id}/events")
+    public ResponseEntity<List<LeadEventResponse>> getEvents(@PathVariable UUID id) {
+        UUID tenantId = UUID.fromString(TenantContext.getTenantId());
+        return ResponseEntity.ok(leadService.getEvents(tenantId, id));
     }
 }

--- a/src/main/java/com/rinoimob/api/controller/PublicController.java
+++ b/src/main/java/com/rinoimob/api/controller/PublicController.java
@@ -1,0 +1,95 @@
+package com.rinoimob.api.controller;
+
+import com.rinoimob.context.TenantContext;
+import com.rinoimob.domain.dto.LeadResponse;
+import com.rinoimob.domain.dto.PublicCreateLeadRequest;
+import com.rinoimob.domain.dto.property.PropertySummaryResponse;
+import com.rinoimob.domain.dto.property.PropertyResponse;
+import com.rinoimob.domain.entity.Lead;
+import com.rinoimob.domain.entity.Tenant;
+import com.rinoimob.domain.enums.LeadStatus;
+import com.rinoimob.domain.enums.PropertyOperation;
+import com.rinoimob.domain.enums.PropertyStatus;
+import com.rinoimob.domain.enums.PropertyType;
+import com.rinoimob.domain.repository.TenantRepository;
+import com.rinoimob.service.LeadService;
+import com.rinoimob.service.PropertyService;
+import com.rinoimob.domain.dto.CreateLeadRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Map;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/public")
+@RequiredArgsConstructor
+public class PublicController {
+
+    private final TenantRepository tenantRepository;
+    private final PropertyService propertyService;
+    private final LeadService leadService;
+
+    @GetMapping("/properties")
+    public ResponseEntity<Page<PropertySummaryResponse>> listProperties(
+            @RequestHeader("X-Tenant-Slug") String tenantSlug,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size,
+            @RequestParam(required = false) PropertyOperation operation,
+            @RequestParam(required = false) PropertyType propertyType) {
+        UUID tenantId = resolveTenant(tenantSlug);
+        TenantContext.setTenantId(tenantId.toString());
+        try {
+            Pageable pageable = PageRequest.of(page, size);
+            return ResponseEntity.ok(propertyService.listProperties(
+                    PropertyStatus.ACTIVE, operation, propertyType,
+                    null, null, null, null, pageable));
+        } finally {
+            TenantContext.clear();
+        }
+    }
+
+    @GetMapping("/properties/{id}")
+    public ResponseEntity<PropertyResponse> getProperty(
+            @RequestHeader("X-Tenant-Slug") String tenantSlug,
+            @PathVariable UUID id) {
+        UUID tenantId = resolveTenant(tenantSlug);
+        TenantContext.setTenantId(tenantId.toString());
+        try {
+            return ResponseEntity.ok(propertyService.getProperty(id));
+        } finally {
+            TenantContext.clear();
+        }
+    }
+
+    @PostMapping("/leads")
+    public ResponseEntity<Map<String, String>> createLead(
+            @RequestHeader("X-Tenant-Slug") String tenantSlug,
+            @Valid @RequestBody PublicCreateLeadRequest request) {
+        if (request.name() == null || request.name().isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "name is required");
+        }
+        UUID tenantId = resolveTenant(tenantSlug);
+        CreateLeadRequest leadReq = new CreateLeadRequest(
+                request.name(), request.email(), request.phone(),
+                request.message(), request.propertyId(), "PORTAL");
+        leadService.create(tenantId, leadReq);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(Map.of("message", "Lead received successfully"));
+    }
+
+    // ── Helper ────────────────────────────────────────────────────────────────
+
+    private UUID resolveTenant(String slug) {
+        return tenantRepository.findBySubdomain(slug)
+                .map(Tenant::getId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Tenant not found"));
+    }
+}

--- a/src/main/java/com/rinoimob/api/controller/UserController.java
+++ b/src/main/java/com/rinoimob/api/controller/UserController.java
@@ -1,8 +1,11 @@
 package com.rinoimob.api.controller;
 
+import com.rinoimob.context.TenantContext;
 import com.rinoimob.domain.dto.ChangePasswordRequest;
 import com.rinoimob.domain.dto.UpdateProfileRequest;
 import com.rinoimob.domain.dto.UserDto;
+import com.rinoimob.domain.entity.User;
+import com.rinoimob.domain.repository.UserRepository;
 import com.rinoimob.service.auth.AuthService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -14,6 +17,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.UUID;
 
 @RestController
@@ -23,9 +27,23 @@ import java.util.UUID;
 public class UserController {
 
     private final AuthService authService;
+    private final UserRepository userRepository;
 
-    public UserController(AuthService authService) {
+    public UserController(AuthService authService, UserRepository userRepository) {
         this.authService = authService;
+        this.userRepository = userRepository;
+    }
+
+    @GetMapping
+    @Operation(summary = "List active users for the current tenant")
+    public ResponseEntity<List<UserDto>> listUsers(HttpServletRequest request) {
+        UUID tenantId = (UUID) request.getAttribute("tenantId");
+        if (tenantId == null) tenantId = UUID.fromString(TenantContext.getTenantId());
+        List<User> users = userRepository.findByTenantIdAndActive(tenantId, true);
+        List<UserDto> dtos = users.stream()
+                .map(u -> new UserDto(u.getId(), u.getEmail(), u.getFirstName(), u.getLastName(), u.getActive(), u.getCreatedAt()))
+                .toList();
+        return ResponseEntity.ok(dtos);
     }
 
     @GetMapping("/profile")

--- a/src/main/java/com/rinoimob/config/security/SecurityConfig.java
+++ b/src/main/java/com/rinoimob/config/security/SecurityConfig.java
@@ -44,6 +44,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.POST, "/api/v1/auth/forgot-password").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/v1/auth/reset-password").permitAll()
                         .requestMatchers("/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                        .requestMatchers("/api/v1/public/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/rinoimob/domain/dto/AddLeadPropertyRequest.java
+++ b/src/main/java/com/rinoimob/domain/dto/AddLeadPropertyRequest.java
@@ -1,0 +1,11 @@
+package com.rinoimob.domain.dto;
+
+import com.rinoimob.domain.enums.InterestLevel;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.UUID;
+
+public record AddLeadPropertyRequest(
+        @NotNull UUID propertyId,
+        InterestLevel interestLevel
+) {}

--- a/src/main/java/com/rinoimob/domain/dto/CreateLeadRequest.java
+++ b/src/main/java/com/rinoimob/domain/dto/CreateLeadRequest.java
@@ -1,0 +1,18 @@
+package com.rinoimob.domain.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+import java.util.UUID;
+
+public record CreateLeadRequest(
+        @NotBlank String name,
+        String email,
+        String phone,
+        String message,
+        UUID propertyId,
+        String source
+) {
+    public CreateLeadRequest {
+        if (source == null) source = "MANUAL";
+    }
+}

--- a/src/main/java/com/rinoimob/domain/dto/LeadEventResponse.java
+++ b/src/main/java/com/rinoimob/domain/dto/LeadEventResponse.java
@@ -1,0 +1,15 @@
+package com.rinoimob.domain.dto;
+
+import com.rinoimob.domain.enums.LeadEventType;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record LeadEventResponse(
+        UUID id,
+        UUID leadId,
+        UUID userId,
+        LeadEventType eventType,
+        String description,
+        LocalDateTime createdAt
+) {}

--- a/src/main/java/com/rinoimob/domain/dto/LeadNoteRequest.java
+++ b/src/main/java/com/rinoimob/domain/dto/LeadNoteRequest.java
@@ -1,0 +1,7 @@
+package com.rinoimob.domain.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record LeadNoteRequest(
+        @NotBlank String content
+) {}

--- a/src/main/java/com/rinoimob/domain/dto/LeadNoteResponse.java
+++ b/src/main/java/com/rinoimob/domain/dto/LeadNoteResponse.java
@@ -1,0 +1,12 @@
+package com.rinoimob.domain.dto;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record LeadNoteResponse(
+        UUID id,
+        UUID leadId,
+        UUID userId,
+        String content,
+        LocalDateTime createdAt
+) {}

--- a/src/main/java/com/rinoimob/domain/dto/LeadPropertyResponse.java
+++ b/src/main/java/com/rinoimob/domain/dto/LeadPropertyResponse.java
@@ -1,0 +1,22 @@
+package com.rinoimob.domain.dto;
+
+import com.rinoimob.domain.enums.InterestLevel;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record LeadPropertyResponse(
+        UUID id,
+        UUID leadId,
+        UUID propertyId,
+        InterestLevel interestLevel,
+        LocalDateTime createdAt,
+        String propertyTitle,
+        String propertyOperation,
+        BigDecimal propertyPrice,
+        String propertyCurrency,
+        String addressCity,
+        String addressState,
+        String coverPhotoUrl
+) {}

--- a/src/main/java/com/rinoimob/domain/dto/LeadResponse.java
+++ b/src/main/java/com/rinoimob/domain/dto/LeadResponse.java
@@ -1,0 +1,23 @@
+package com.rinoimob.domain.dto;
+
+import com.rinoimob.domain.enums.LeadStatus;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+public record LeadResponse(
+        UUID id,
+        UUID tenantId,
+        UUID propertyId,
+        String name,
+        String email,
+        String phone,
+        String message,
+        LeadStatus status,
+        String source,
+        UUID assignedTo,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt,
+        List<LeadNoteResponse> notes
+) {}

--- a/src/main/java/com/rinoimob/domain/dto/LeadResponse.java
+++ b/src/main/java/com/rinoimob/domain/dto/LeadResponse.java
@@ -20,5 +20,6 @@ public record LeadResponse(
         String assignedToName,
         LocalDateTime createdAt,
         LocalDateTime updatedAt,
-        List<LeadNoteResponse> notes
+        List<LeadNoteResponse> notes,
+        List<LeadPropertyResponse> properties
 ) {}

--- a/src/main/java/com/rinoimob/domain/dto/LeadResponse.java
+++ b/src/main/java/com/rinoimob/domain/dto/LeadResponse.java
@@ -17,6 +17,7 @@ public record LeadResponse(
         LeadStatus status,
         String source,
         UUID assignedTo,
+        String assignedToName,
         LocalDateTime createdAt,
         LocalDateTime updatedAt,
         List<LeadNoteResponse> notes

--- a/src/main/java/com/rinoimob/domain/dto/LeadStatsResponse.java
+++ b/src/main/java/com/rinoimob/domain/dto/LeadStatsResponse.java
@@ -1,0 +1,12 @@
+package com.rinoimob.domain.dto;
+
+public record LeadStatsResponse(
+    long total,
+    long newLeads,
+    long contacted,
+    long qualified,
+    long won,
+    long lost,
+    long thisWeek,
+    double conversionRate   // won / (won + lost) * 100, 0 if both are 0
+) {}

--- a/src/main/java/com/rinoimob/domain/dto/PublicCreateLeadRequest.java
+++ b/src/main/java/com/rinoimob/domain/dto/PublicCreateLeadRequest.java
@@ -1,0 +1,13 @@
+package com.rinoimob.domain.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+import java.util.UUID;
+
+public record PublicCreateLeadRequest(
+        @NotBlank String name,
+        String email,
+        String phone,
+        String message,
+        UUID propertyId
+) {}

--- a/src/main/java/com/rinoimob/domain/dto/UpdateLeadPropertyRequest.java
+++ b/src/main/java/com/rinoimob/domain/dto/UpdateLeadPropertyRequest.java
@@ -1,0 +1,6 @@
+package com.rinoimob.domain.dto;
+
+import com.rinoimob.domain.enums.InterestLevel;
+import jakarta.validation.constraints.NotNull;
+
+public record UpdateLeadPropertyRequest(@NotNull InterestLevel interestLevel) {}

--- a/src/main/java/com/rinoimob/domain/dto/UpdateLeadRequest.java
+++ b/src/main/java/com/rinoimob/domain/dto/UpdateLeadRequest.java
@@ -1,0 +1,14 @@
+package com.rinoimob.domain.dto;
+
+import com.rinoimob.domain.enums.LeadStatus;
+
+import java.util.UUID;
+
+public record UpdateLeadRequest(
+        String name,
+        String email,
+        String phone,
+        String message,
+        LeadStatus status,
+        UUID assignedTo
+) {}

--- a/src/main/java/com/rinoimob/domain/entity/Lead.java
+++ b/src/main/java/com/rinoimob/domain/entity/Lead.java
@@ -1,5 +1,6 @@
 package com.rinoimob.domain.entity;
 
+import com.rinoimob.domain.enums.LeadStatus;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -19,37 +20,40 @@ public class Lead {
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 
-    @Column(nullable = false)
+    @Column(name = "tenant_id", nullable = false)
     private UUID tenantId;
 
     @Column(name = "property_id")
     private UUID propertyId;
 
-    @Column(nullable = false, name = "first_name")
-    private String firstName;
-
-    @Column(nullable = false, name = "last_name")
-    private String lastName;
+    @Column(nullable = false, length = 200)
+    private String name;
 
     private String email;
 
     private String phone;
 
-    @Column(columnDefinition = "VARCHAR(50) DEFAULT 'new'")
-    private String status = "new";
+    @Column(columnDefinition = "TEXT")
+    private String message;
 
-    private String source;
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private LeadStatus status = LeadStatus.NEW;
+
+    @Column(length = 50)
+    private String source = "PORTAL";
 
     @Column(name = "assigned_to")
     private UUID assignedTo;
 
-    private String notes;
-
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
-    @Column(name = "updated_at")
+    @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
 
     @PrePersist
     protected void onCreate() {
@@ -61,5 +65,4 @@ public class Lead {
     protected void onUpdate() {
         updatedAt = LocalDateTime.now();
     }
-
 }

--- a/src/main/java/com/rinoimob/domain/entity/LeadEvent.java
+++ b/src/main/java/com/rinoimob/domain/entity/LeadEvent.java
@@ -1,0 +1,41 @@
+package com.rinoimob.domain.entity;
+
+import com.rinoimob.domain.enums.LeadEventType;
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "lead_events")
+@Data
+@NoArgsConstructor
+public class LeadEvent {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "lead_id", nullable = false)
+    private UUID leadId;
+
+    @Column(name = "user_id")
+    private UUID userId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "event_type", nullable = false, length = 30)
+    private LeadEventType eventType;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/rinoimob/domain/entity/LeadNote.java
+++ b/src/main/java/com/rinoimob/domain/entity/LeadNote.java
@@ -1,0 +1,38 @@
+package com.rinoimob.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "lead_notes")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class LeadNote {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "lead_id", nullable = false)
+    private UUID leadId;
+
+    @Column(name = "user_id", nullable = false)
+    private UUID userId;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/rinoimob/domain/entity/LeadProperty.java
+++ b/src/main/java/com/rinoimob/domain/entity/LeadProperty.java
@@ -1,0 +1,40 @@
+package com.rinoimob.domain.entity;
+
+import com.rinoimob.domain.enums.InterestLevel;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "lead_properties")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class LeadProperty {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "lead_id", nullable = false)
+    private UUID leadId;
+
+    @Column(name = "property_id", nullable = false)
+    private UUID propertyId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "interest_level", nullable = false, length = 20)
+    private InterestLevel interestLevel = InterestLevel.UNDEFINED;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/rinoimob/domain/enums/InterestLevel.java
+++ b/src/main/java/com/rinoimob/domain/enums/InterestLevel.java
@@ -1,0 +1,3 @@
+package com.rinoimob.domain.enums;
+
+public enum InterestLevel { UNDEFINED, LOW, MEDIUM, HIGH }

--- a/src/main/java/com/rinoimob/domain/enums/LeadEventType.java
+++ b/src/main/java/com/rinoimob/domain/enums/LeadEventType.java
@@ -1,0 +1,11 @@
+package com.rinoimob.domain.enums;
+
+public enum LeadEventType {
+    CREATED,
+    STATUS_CHANGED,
+    ASSIGNED,
+    UNASSIGNED,
+    NOTE_ADDED,
+    PROPERTY_LINKED,
+    PROPERTY_UNLINKED
+}

--- a/src/main/java/com/rinoimob/domain/enums/LeadStatus.java
+++ b/src/main/java/com/rinoimob/domain/enums/LeadStatus.java
@@ -1,0 +1,5 @@
+package com.rinoimob.domain.enums;
+
+public enum LeadStatus {
+    NEW, CONTACTED, QUALIFIED, LOST, WON
+}

--- a/src/main/java/com/rinoimob/domain/repository/LeadEventRepository.java
+++ b/src/main/java/com/rinoimob/domain/repository/LeadEventRepository.java
@@ -1,0 +1,14 @@
+package com.rinoimob.domain.repository;
+
+import com.rinoimob.domain.entity.LeadEvent;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface LeadEventRepository extends JpaRepository<LeadEvent, UUID> {
+
+    List<LeadEvent> findAllByLeadIdOrderByCreatedAtDesc(UUID leadId);
+}

--- a/src/main/java/com/rinoimob/domain/repository/LeadNoteRepository.java
+++ b/src/main/java/com/rinoimob/domain/repository/LeadNoteRepository.java
@@ -1,0 +1,14 @@
+package com.rinoimob.domain.repository;
+
+import com.rinoimob.domain.entity.LeadNote;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface LeadNoteRepository extends JpaRepository<LeadNote, UUID> {
+
+    List<LeadNote> findAllByLeadIdOrderByCreatedAtDesc(UUID leadId);
+}

--- a/src/main/java/com/rinoimob/domain/repository/LeadPropertyRepository.java
+++ b/src/main/java/com/rinoimob/domain/repository/LeadPropertyRepository.java
@@ -1,0 +1,23 @@
+package com.rinoimob.domain.repository;
+
+import com.rinoimob.domain.entity.LeadProperty;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface LeadPropertyRepository extends JpaRepository<LeadProperty, UUID> {
+
+    List<LeadProperty> findAllByLeadIdOrderByCreatedAtAsc(UUID leadId);
+
+    boolean existsByLeadIdAndPropertyId(UUID leadId, UUID propertyId);
+
+    Optional<LeadProperty> findByIdAndLeadId(UUID id, UUID leadId);
+
+    @Transactional
+    void deleteByLeadIdAndPropertyId(UUID leadId, UUID propertyId);
+}

--- a/src/main/java/com/rinoimob/domain/repository/LeadRepository.java
+++ b/src/main/java/com/rinoimob/domain/repository/LeadRepository.java
@@ -5,6 +5,8 @@ import com.rinoimob.domain.enums.LeadStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -21,4 +23,11 @@ public interface LeadRepository extends JpaRepository<Lead, UUID> {
     Optional<Lead> findByIdAndTenantIdAndDeletedAtIsNull(UUID id, UUID tenantId);
 
     List<Lead> findAllByTenantIdAndDeletedAtIsNullAndStatus(UUID tenantId, LeadStatus status);
+
+    long countByTenantIdAndDeletedAtIsNull(UUID tenantId);
+
+    long countByTenantIdAndStatusAndDeletedAtIsNull(UUID tenantId, LeadStatus status);
+
+    @Query("SELECT COUNT(l) FROM Lead l WHERE l.tenantId = :tenantId AND l.deletedAt IS NULL AND l.createdAt >= :since")
+    long countByTenantIdAndCreatedAtAfterAndDeletedAtIsNull(UUID tenantId, @Param("since") java.time.LocalDateTime since);
 }

--- a/src/main/java/com/rinoimob/domain/repository/LeadRepository.java
+++ b/src/main/java/com/rinoimob/domain/repository/LeadRepository.java
@@ -1,19 +1,24 @@
 package com.rinoimob.domain.repository;
 
 import com.rinoimob.domain.entity.Lead;
+import com.rinoimob.domain.enums.LeadStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 @Repository
 public interface LeadRepository extends JpaRepository<Lead, UUID> {
 
-    List<Lead> findByTenantId(UUID tenantId);
+    Page<Lead> findAllByTenantIdAndDeletedAtIsNull(UUID tenantId, Pageable pageable);
 
-    List<Lead> findByTenantIdAndStatus(UUID tenantId, String status);
+    Page<Lead> findAllByTenantIdAndStatusAndDeletedAtIsNull(UUID tenantId, LeadStatus status, Pageable pageable);
 
-    List<Lead> findByTenantIdAndAssignedTo(UUID tenantId, UUID assignedTo);
+    Optional<Lead> findByIdAndTenantIdAndDeletedAtIsNull(UUID id, UUID tenantId);
 
+    List<Lead> findAllByTenantIdAndDeletedAtIsNullAndStatus(UUID tenantId, LeadStatus status);
 }

--- a/src/main/java/com/rinoimob/domain/repository/PropertyRepository.java
+++ b/src/main/java/com/rinoimob/domain/repository/PropertyRepository.java
@@ -3,6 +3,8 @@ package com.rinoimob.domain.repository;
 import com.rinoimob.domain.entity.Property;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -12,4 +14,7 @@ import java.util.UUID;
 public interface PropertyRepository extends JpaRepository<Property, UUID>, JpaSpecificationExecutor<Property> {
 
     Optional<Property> findByIdAndTenantIdAndDeletedAtIsNull(UUID id, UUID tenantId);
+
+    @Query("SELECT p FROM Property p LEFT JOIN FETCH p.photos WHERE p.id = :id")
+    Optional<Property> findByIdWithPhotos(@Param("id") UUID id);
 }

--- a/src/main/java/com/rinoimob/service/LeadService.java
+++ b/src/main/java/com/rinoimob/service/LeadService.java
@@ -3,10 +3,15 @@ package com.rinoimob.service;
 import com.rinoimob.context.TenantContext;
 import com.rinoimob.domain.dto.*;
 import com.rinoimob.domain.entity.Lead;
+import com.rinoimob.domain.entity.LeadEvent;
 import com.rinoimob.domain.entity.LeadNote;
+import com.rinoimob.domain.entity.User;
+import com.rinoimob.domain.enums.LeadEventType;
 import com.rinoimob.domain.enums.LeadStatus;
+import com.rinoimob.domain.repository.LeadEventRepository;
 import com.rinoimob.domain.repository.LeadNoteRepository;
 import com.rinoimob.domain.repository.LeadRepository;
+import com.rinoimob.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -28,23 +33,25 @@ public class LeadService {
 
     private final LeadRepository leadRepository;
     private final LeadNoteRepository leadNoteRepository;
+    private final LeadEventRepository leadEventRepository;
+    private final UserRepository userRepository;
 
     @Transactional(readOnly = true)
     public Page<LeadResponse> list(UUID tenantId, LeadStatus status, int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
         if (status != null) {
             return leadRepository.findAllByTenantIdAndStatusAndDeletedAtIsNull(tenantId, status, pageable)
-                    .map(l -> toResponse(l, List.of()));
+                    .map(l -> toResponse(l, List.of(), resolveUserName(l.getAssignedTo())));
         }
         return leadRepository.findAllByTenantIdAndDeletedAtIsNull(tenantId, pageable)
-                .map(l -> toResponse(l, List.of()));
+                .map(l -> toResponse(l, List.of(), resolveUserName(l.getAssignedTo())));
     }
 
     @Transactional(readOnly = true)
     public LeadResponse get(UUID tenantId, UUID id) {
         Lead lead = findOwned(id, tenantId);
         List<LeadNote> notes = leadNoteRepository.findAllByLeadIdOrderByCreatedAtDesc(id);
-        return toResponse(lead, notes);
+        return toResponse(lead, notes, resolveUserName(lead.getAssignedTo()));
     }
 
     @Transactional
@@ -59,8 +66,9 @@ public class LeadService {
         lead.setSource(req.source() != null ? req.source() : "MANUAL");
         lead.setStatus(LeadStatus.NEW);
         lead = leadRepository.save(lead);
+        logEvent(lead.getId(), null, LeadEventType.CREATED, "Lead criado via " + lead.getSource());
         log.info("Lead created id={} tenant={}", lead.getId(), tenantId);
-        return toResponse(lead, List.of());
+        return toResponse(lead, List.of(), null);
     }
 
     @Transactional
@@ -70,12 +78,22 @@ public class LeadService {
         if (req.email() != null) lead.setEmail(req.email());
         if (req.phone() != null) lead.setPhone(req.phone());
         if (req.message() != null) lead.setMessage(req.message());
-        if (req.status() != null) lead.setStatus(req.status());
-        if (req.assignedTo() != null) lead.setAssignedTo(req.assignedTo());
+        if (req.status() != null && !req.status().equals(lead.getStatus())) {
+            LeadStatus oldStatus = lead.getStatus();
+            lead.setStatus(req.status());
+            logEvent(lead.getId(), null, LeadEventType.STATUS_CHANGED,
+                    "Status alterado de " + oldStatus + " para " + req.status());
+        }
+        if (req.assignedTo() != null && !req.assignedTo().equals(lead.getAssignedTo())) {
+            lead.setAssignedTo(req.assignedTo());
+            String userName = resolveUserName(req.assignedTo());
+            logEvent(lead.getId(), null, LeadEventType.ASSIGNED,
+                    "Atribuído a " + (userName != null ? userName : req.assignedTo()));
+        }
         lead = leadRepository.save(lead);
         log.info("Lead updated id={}", id);
         List<LeadNote> notes = leadNoteRepository.findAllByLeadIdOrderByCreatedAtDesc(id);
-        return toResponse(lead, notes);
+        return toResponse(lead, notes, resolveUserName(lead.getAssignedTo()));
     }
 
     @Transactional
@@ -94,8 +112,16 @@ public class LeadService {
         note.setUserId(userId);
         note.setContent(req.content());
         note = leadNoteRepository.save(note);
+        logEvent(leadId, userId, LeadEventType.NOTE_ADDED, "Nota adicionada");
         log.info("Note added to lead={} by user={}", leadId, userId);
         return toNoteResponse(note);
+    }
+
+    @Transactional(readOnly = true)
+    public List<LeadEventResponse> getEvents(UUID tenantId, UUID leadId) {
+        findOwned(leadId, tenantId);
+        return leadEventRepository.findAllByLeadIdOrderByCreatedAtDesc(leadId)
+                .stream().map(this::toEventResponse).toList();
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────
@@ -105,11 +131,30 @@ public class LeadService {
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Lead not found"));
     }
 
-    public LeadResponse toResponse(Lead l, List<LeadNote> notes) {
+    private void logEvent(UUID leadId, UUID userId, LeadEventType type, String description) {
+        LeadEvent event = new LeadEvent();
+        event.setLeadId(leadId);
+        event.setUserId(userId);
+        event.setEventType(type);
+        event.setDescription(description);
+        leadEventRepository.save(event);
+    }
+
+    private String resolveUserName(UUID userId) {
+        if (userId == null) return null;
+        return userRepository.findById(userId).map(u -> {
+            if (u.getFirstName() != null && !u.getFirstName().isBlank()) {
+                return u.getLastName() != null ? u.getFirstName() + " " + u.getLastName() : u.getFirstName();
+            }
+            return u.getEmail();
+        }).orElse(null);
+    }
+
+    public LeadResponse toResponse(Lead l, List<LeadNote> notes, String assignedToName) {
         return new LeadResponse(
                 l.getId(), l.getTenantId(), l.getPropertyId(),
                 l.getName(), l.getEmail(), l.getPhone(), l.getMessage(),
-                l.getStatus(), l.getSource(), l.getAssignedTo(),
+                l.getStatus(), l.getSource(), l.getAssignedTo(), assignedToName,
                 l.getCreatedAt(), l.getUpdatedAt(),
                 notes.stream().map(this::toNoteResponse).toList()
         );
@@ -117,5 +162,9 @@ public class LeadService {
 
     private LeadNoteResponse toNoteResponse(LeadNote n) {
         return new LeadNoteResponse(n.getId(), n.getLeadId(), n.getUserId(), n.getContent(), n.getCreatedAt());
+    }
+
+    private LeadEventResponse toEventResponse(LeadEvent e) {
+        return new LeadEventResponse(e.getId(), e.getLeadId(), e.getUserId(), e.getEventType(), e.getDescription(), e.getCreatedAt());
     }
 }

--- a/src/main/java/com/rinoimob/service/LeadService.java
+++ b/src/main/java/com/rinoimob/service/LeadService.java
@@ -178,6 +178,14 @@ public class LeadService {
         logEvent(leadId, null, LeadEventType.PROPERTY_UNLINKED, "Imóvel desvinculado");
     }
 
+    @Transactional(readOnly = true)
+    public List<LeadPropertyResponse> getProperties(UUID tenantId, UUID leadId) {
+        findOwned(leadId, tenantId);
+        return leadPropertyRepository.findAllByLeadIdOrderByCreatedAtAsc(leadId).stream()
+                .map(this::toLeadPropertyResponse)
+                .toList();
+    }
+
     // ── Helpers ───────────────────────────────────────────────────────────────
 
     private Lead findOwned(UUID id, UUID tenantId) {
@@ -213,10 +221,11 @@ public class LeadService {
         Property p = propOpt.get();
         String coverUrl = p.getPhotos().stream()
                 .filter(ph -> Boolean.TRUE.equals(ph.getIsCover()))
-                .findFirst().map(PropertyPhoto::getUrl).orElse(null);
+                .findFirst().map(PropertyPhoto::getUrl)
+                .orElseGet(() -> p.getPhotos().stream().findFirst().map(PropertyPhoto::getUrl).orElse(null));
         return new LeadPropertyResponse(lp.getId(), lp.getLeadId(), lp.getPropertyId(),
                 lp.getInterestLevel(), lp.getCreatedAt(),
-                p.getTitle(), p.getOperation().name(), p.getPrice(), p.getCurrency(),
+                p.getTitle(), p.getOperation() != null ? p.getOperation().name() : null, p.getPrice(), p.getCurrency(),
                 p.getAddressCity(), p.getAddressState(), coverUrl);
     }
 

--- a/src/main/java/com/rinoimob/service/LeadService.java
+++ b/src/main/java/com/rinoimob/service/LeadService.java
@@ -1,0 +1,121 @@
+package com.rinoimob.service;
+
+import com.rinoimob.context.TenantContext;
+import com.rinoimob.domain.dto.*;
+import com.rinoimob.domain.entity.Lead;
+import com.rinoimob.domain.entity.LeadNote;
+import com.rinoimob.domain.enums.LeadStatus;
+import com.rinoimob.domain.repository.LeadNoteRepository;
+import com.rinoimob.domain.repository.LeadRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class LeadService {
+
+    private final LeadRepository leadRepository;
+    private final LeadNoteRepository leadNoteRepository;
+
+    @Transactional(readOnly = true)
+    public Page<LeadResponse> list(UUID tenantId, LeadStatus status, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        if (status != null) {
+            return leadRepository.findAllByTenantIdAndStatusAndDeletedAtIsNull(tenantId, status, pageable)
+                    .map(l -> toResponse(l, List.of()));
+        }
+        return leadRepository.findAllByTenantIdAndDeletedAtIsNull(tenantId, pageable)
+                .map(l -> toResponse(l, List.of()));
+    }
+
+    @Transactional(readOnly = true)
+    public LeadResponse get(UUID tenantId, UUID id) {
+        Lead lead = findOwned(id, tenantId);
+        List<LeadNote> notes = leadNoteRepository.findAllByLeadIdOrderByCreatedAtDesc(id);
+        return toResponse(lead, notes);
+    }
+
+    @Transactional
+    public LeadResponse create(UUID tenantId, CreateLeadRequest req) {
+        Lead lead = new Lead();
+        lead.setTenantId(tenantId);
+        lead.setName(req.name());
+        lead.setEmail(req.email());
+        lead.setPhone(req.phone());
+        lead.setMessage(req.message());
+        lead.setPropertyId(req.propertyId());
+        lead.setSource(req.source() != null ? req.source() : "MANUAL");
+        lead.setStatus(LeadStatus.NEW);
+        lead = leadRepository.save(lead);
+        log.info("Lead created id={} tenant={}", lead.getId(), tenantId);
+        return toResponse(lead, List.of());
+    }
+
+    @Transactional
+    public LeadResponse update(UUID tenantId, UUID id, UpdateLeadRequest req) {
+        Lead lead = findOwned(id, tenantId);
+        if (req.name() != null) lead.setName(req.name());
+        if (req.email() != null) lead.setEmail(req.email());
+        if (req.phone() != null) lead.setPhone(req.phone());
+        if (req.message() != null) lead.setMessage(req.message());
+        if (req.status() != null) lead.setStatus(req.status());
+        if (req.assignedTo() != null) lead.setAssignedTo(req.assignedTo());
+        lead = leadRepository.save(lead);
+        log.info("Lead updated id={}", id);
+        List<LeadNote> notes = leadNoteRepository.findAllByLeadIdOrderByCreatedAtDesc(id);
+        return toResponse(lead, notes);
+    }
+
+    @Transactional
+    public void delete(UUID tenantId, UUID id) {
+        Lead lead = findOwned(id, tenantId);
+        lead.setDeletedAt(LocalDateTime.now());
+        leadRepository.save(lead);
+        log.info("Lead soft-deleted id={}", id);
+    }
+
+    @Transactional
+    public LeadNoteResponse addNote(UUID tenantId, UUID leadId, UUID userId, LeadNoteRequest req) {
+        findOwned(leadId, tenantId);
+        LeadNote note = new LeadNote();
+        note.setLeadId(leadId);
+        note.setUserId(userId);
+        note.setContent(req.content());
+        note = leadNoteRepository.save(note);
+        log.info("Note added to lead={} by user={}", leadId, userId);
+        return toNoteResponse(note);
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private Lead findOwned(UUID id, UUID tenantId) {
+        return leadRepository.findByIdAndTenantIdAndDeletedAtIsNull(id, tenantId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Lead not found"));
+    }
+
+    public LeadResponse toResponse(Lead l, List<LeadNote> notes) {
+        return new LeadResponse(
+                l.getId(), l.getTenantId(), l.getPropertyId(),
+                l.getName(), l.getEmail(), l.getPhone(), l.getMessage(),
+                l.getStatus(), l.getSource(), l.getAssignedTo(),
+                l.getCreatedAt(), l.getUpdatedAt(),
+                notes.stream().map(this::toNoteResponse).toList()
+        );
+    }
+
+    private LeadNoteResponse toNoteResponse(LeadNote n) {
+        return new LeadNoteResponse(n.getId(), n.getLeadId(), n.getUserId(), n.getContent(), n.getCreatedAt());
+    }
+}

--- a/src/main/java/com/rinoimob/service/LeadService.java
+++ b/src/main/java/com/rinoimob/service/LeadService.java
@@ -46,6 +46,20 @@ public class LeadService {
     private final PropertyRepository propertyRepository;
 
     @Transactional(readOnly = true)
+    public LeadStatsResponse getStats(UUID tenantId) {
+        long total = leadRepository.countByTenantIdAndDeletedAtIsNull(tenantId);
+        long newLeads = leadRepository.countByTenantIdAndStatusAndDeletedAtIsNull(tenantId, LeadStatus.NEW);
+        long contacted = leadRepository.countByTenantIdAndStatusAndDeletedAtIsNull(tenantId, LeadStatus.CONTACTED);
+        long qualified = leadRepository.countByTenantIdAndStatusAndDeletedAtIsNull(tenantId, LeadStatus.QUALIFIED);
+        long won = leadRepository.countByTenantIdAndStatusAndDeletedAtIsNull(tenantId, LeadStatus.WON);
+        long lost = leadRepository.countByTenantIdAndStatusAndDeletedAtIsNull(tenantId, LeadStatus.LOST);
+        LocalDateTime weekAgo = LocalDateTime.now().minusDays(7);
+        long thisWeek = leadRepository.countByTenantIdAndCreatedAtAfterAndDeletedAtIsNull(tenantId, weekAgo);
+        double conversionRate = (won + lost) > 0 ? (double) won / (won + lost) * 100 : 0;
+        return new LeadStatsResponse(total, newLeads, contacted, qualified, won, lost, thisWeek, conversionRate);
+    }
+
+    @Transactional(readOnly = true)
     public Page<LeadResponse> list(UUID tenantId, LeadStatus status, int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
         if (status != null) {

--- a/src/main/java/com/rinoimob/service/LeadService.java
+++ b/src/main/java/com/rinoimob/service/LeadService.java
@@ -5,12 +5,18 @@ import com.rinoimob.domain.dto.*;
 import com.rinoimob.domain.entity.Lead;
 import com.rinoimob.domain.entity.LeadEvent;
 import com.rinoimob.domain.entity.LeadNote;
+import com.rinoimob.domain.entity.LeadProperty;
+import com.rinoimob.domain.entity.Property;
+import com.rinoimob.domain.entity.PropertyPhoto;
 import com.rinoimob.domain.entity.User;
+import com.rinoimob.domain.enums.InterestLevel;
 import com.rinoimob.domain.enums.LeadEventType;
 import com.rinoimob.domain.enums.LeadStatus;
 import com.rinoimob.domain.repository.LeadEventRepository;
 import com.rinoimob.domain.repository.LeadNoteRepository;
+import com.rinoimob.domain.repository.LeadPropertyRepository;
 import com.rinoimob.domain.repository.LeadRepository;
+import com.rinoimob.domain.repository.PropertyRepository;
 import com.rinoimob.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -24,6 +30,7 @@ import org.springframework.web.server.ResponseStatusException;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 @Service
@@ -35,23 +42,27 @@ public class LeadService {
     private final LeadNoteRepository leadNoteRepository;
     private final LeadEventRepository leadEventRepository;
     private final UserRepository userRepository;
+    private final LeadPropertyRepository leadPropertyRepository;
+    private final PropertyRepository propertyRepository;
 
     @Transactional(readOnly = true)
     public Page<LeadResponse> list(UUID tenantId, LeadStatus status, int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
         if (status != null) {
             return leadRepository.findAllByTenantIdAndStatusAndDeletedAtIsNull(tenantId, status, pageable)
-                    .map(l -> toResponse(l, List.of(), resolveUserName(l.getAssignedTo())));
+                    .map(l -> toResponse(l, List.of(), resolveUserName(l.getAssignedTo()), List.of()));
         }
         return leadRepository.findAllByTenantIdAndDeletedAtIsNull(tenantId, pageable)
-                .map(l -> toResponse(l, List.of(), resolveUserName(l.getAssignedTo())));
+                .map(l -> toResponse(l, List.of(), resolveUserName(l.getAssignedTo()), List.of()));
     }
 
     @Transactional(readOnly = true)
     public LeadResponse get(UUID tenantId, UUID id) {
         Lead lead = findOwned(id, tenantId);
         List<LeadNote> notes = leadNoteRepository.findAllByLeadIdOrderByCreatedAtDesc(id);
-        return toResponse(lead, notes, resolveUserName(lead.getAssignedTo()));
+        List<LeadProperty> leadProps = leadPropertyRepository.findAllByLeadIdOrderByCreatedAtAsc(id);
+        List<LeadPropertyResponse> propResponses = leadProps.stream().map(this::toLeadPropertyResponse).toList();
+        return toResponse(lead, notes, resolveUserName(lead.getAssignedTo()), propResponses);
     }
 
     @Transactional
@@ -67,8 +78,15 @@ public class LeadService {
         lead.setStatus(LeadStatus.NEW);
         lead = leadRepository.save(lead);
         logEvent(lead.getId(), null, LeadEventType.CREATED, "Lead criado via " + lead.getSource());
+        if (req.propertyId() != null && !leadPropertyRepository.existsByLeadIdAndPropertyId(lead.getId(), req.propertyId())) {
+            LeadProperty lp = new LeadProperty();
+            lp.setLeadId(lead.getId());
+            lp.setPropertyId(req.propertyId());
+            lp.setInterestLevel(InterestLevel.UNDEFINED);
+            leadPropertyRepository.save(lp);
+        }
         log.info("Lead created id={} tenant={}", lead.getId(), tenantId);
-        return toResponse(lead, List.of(), null);
+        return toResponse(lead, List.of(), null, List.of());
     }
 
     @Transactional
@@ -93,7 +111,9 @@ public class LeadService {
         lead = leadRepository.save(lead);
         log.info("Lead updated id={}", id);
         List<LeadNote> notes = leadNoteRepository.findAllByLeadIdOrderByCreatedAtDesc(id);
-        return toResponse(lead, notes, resolveUserName(lead.getAssignedTo()));
+        List<LeadProperty> leadProps = leadPropertyRepository.findAllByLeadIdOrderByCreatedAtAsc(id);
+        List<LeadPropertyResponse> propResponses = leadProps.stream().map(this::toLeadPropertyResponse).toList();
+        return toResponse(lead, notes, resolveUserName(lead.getAssignedTo()), propResponses);
     }
 
     @Transactional
@@ -124,6 +144,40 @@ public class LeadService {
                 .stream().map(this::toEventResponse).toList();
     }
 
+    @Transactional
+    public LeadPropertyResponse addProperty(UUID tenantId, UUID leadId, AddLeadPropertyRequest req) {
+        findOwned(leadId, tenantId);
+        if (leadPropertyRepository.existsByLeadIdAndPropertyId(leadId, req.propertyId())) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "Property already linked to this lead");
+        }
+        LeadProperty lp = new LeadProperty();
+        lp.setLeadId(leadId);
+        lp.setPropertyId(req.propertyId());
+        lp.setInterestLevel(req.interestLevel() != null ? req.interestLevel() : InterestLevel.UNDEFINED);
+        lp = leadPropertyRepository.save(lp);
+        logEvent(leadId, null, LeadEventType.PROPERTY_LINKED, "Imóvel vinculado: " + req.propertyId());
+        return toLeadPropertyResponse(lp);
+    }
+
+    @Transactional
+    public LeadPropertyResponse updatePropertyInterest(UUID tenantId, UUID leadId, UUID linkId, UpdateLeadPropertyRequest req) {
+        findOwned(leadId, tenantId);
+        LeadProperty lp = leadPropertyRepository.findByIdAndLeadId(linkId, leadId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Link not found"));
+        lp.setInterestLevel(req.interestLevel());
+        lp = leadPropertyRepository.save(lp);
+        return toLeadPropertyResponse(lp);
+    }
+
+    @Transactional
+    public void removeProperty(UUID tenantId, UUID leadId, UUID linkId) {
+        findOwned(leadId, tenantId);
+        LeadProperty lp = leadPropertyRepository.findByIdAndLeadId(linkId, leadId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Link not found"));
+        leadPropertyRepository.delete(lp);
+        logEvent(leadId, null, LeadEventType.PROPERTY_UNLINKED, "Imóvel desvinculado");
+    }
+
     // ── Helpers ───────────────────────────────────────────────────────────────
 
     private Lead findOwned(UUID id, UUID tenantId) {
@@ -150,13 +204,30 @@ public class LeadService {
         }).orElse(null);
     }
 
-    public LeadResponse toResponse(Lead l, List<LeadNote> notes, String assignedToName) {
+    private LeadPropertyResponse toLeadPropertyResponse(LeadProperty lp) {
+        Optional<Property> propOpt = propertyRepository.findByIdWithPhotos(lp.getPropertyId());
+        if (propOpt.isEmpty()) {
+            return new LeadPropertyResponse(lp.getId(), lp.getLeadId(), lp.getPropertyId(),
+                    lp.getInterestLevel(), lp.getCreatedAt(), null, null, null, null, null, null, null);
+        }
+        Property p = propOpt.get();
+        String coverUrl = p.getPhotos().stream()
+                .filter(ph -> Boolean.TRUE.equals(ph.getIsCover()))
+                .findFirst().map(PropertyPhoto::getUrl).orElse(null);
+        return new LeadPropertyResponse(lp.getId(), lp.getLeadId(), lp.getPropertyId(),
+                lp.getInterestLevel(), lp.getCreatedAt(),
+                p.getTitle(), p.getOperation().name(), p.getPrice(), p.getCurrency(),
+                p.getAddressCity(), p.getAddressState(), coverUrl);
+    }
+
+    public LeadResponse toResponse(Lead l, List<LeadNote> notes, String assignedToName, List<LeadPropertyResponse> properties) {
         return new LeadResponse(
                 l.getId(), l.getTenantId(), l.getPropertyId(),
                 l.getName(), l.getEmail(), l.getPhone(), l.getMessage(),
                 l.getStatus(), l.getSource(), l.getAssignedTo(), assignedToName,
                 l.getCreatedAt(), l.getUpdatedAt(),
-                notes.stream().map(this::toNoteResponse).toList()
+                notes.stream().map(this::toNoteResponse).toList(),
+                properties
         );
     }
 

--- a/src/main/resources/db/migration/V6__create_leads_tables.sql
+++ b/src/main/resources/db/migration/V6__create_leads_tables.sql
@@ -1,0 +1,38 @@
+-- V6: Replace Phase 0 placeholder leads table with full Phase 3 spec.
+-- Add lead_notes table.
+
+DROP TABLE IF EXISTS leads CASCADE;
+
+CREATE TABLE leads (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id UUID NOT NULL REFERENCES tenants(id),
+    property_id UUID REFERENCES properties(id) ON DELETE SET NULL,
+    name VARCHAR(200) NOT NULL,
+    email VARCHAR(255),
+    phone VARCHAR(30),
+    message TEXT,
+    status VARCHAR(20) NOT NULL DEFAULT 'NEW',
+    source VARCHAR(50) DEFAULT 'PORTAL',
+    assigned_to UUID REFERENCES users(id) ON DELETE SET NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    deleted_at TIMESTAMP
+);
+
+CREATE INDEX idx_leads_tenant_id ON leads(tenant_id);
+CREATE INDEX idx_leads_property_id ON leads(property_id);
+CREATE INDEX idx_leads_assigned_to ON leads(assigned_to);
+CREATE INDEX idx_leads_status ON leads(status);
+CREATE INDEX idx_leads_created_at ON leads(created_at);
+CREATE INDEX idx_leads_deleted_at ON leads(deleted_at);
+
+CREATE TABLE lead_notes (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    lead_id UUID NOT NULL REFERENCES leads(id) ON DELETE CASCADE,
+    user_id UUID NOT NULL REFERENCES users(id),
+    content TEXT NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_lead_notes_lead_id ON lead_notes(lead_id);
+CREATE INDEX idx_lead_notes_user_id ON lead_notes(user_id);

--- a/src/main/resources/db/migration/V7__lead_events.sql
+++ b/src/main/resources/db/migration/V7__lead_events.sql
@@ -1,0 +1,9 @@
+CREATE TABLE lead_events (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    lead_id UUID NOT NULL REFERENCES leads(id) ON DELETE CASCADE,
+    user_id UUID REFERENCES users(id) ON DELETE SET NULL,
+    event_type VARCHAR(30) NOT NULL,
+    description TEXT,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+CREATE INDEX idx_lead_events_lead_id ON lead_events(lead_id);

--- a/src/main/resources/db/migration/V8__lead_properties.sql
+++ b/src/main/resources/db/migration/V8__lead_properties.sql
@@ -1,0 +1,16 @@
+CREATE TABLE lead_properties (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    lead_id UUID NOT NULL REFERENCES leads(id) ON DELETE CASCADE,
+    property_id UUID NOT NULL REFERENCES properties(id) ON DELETE CASCADE,
+    interest_level VARCHAR(20) NOT NULL DEFAULT 'UNDEFINED',
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    UNIQUE (lead_id, property_id)
+);
+CREATE INDEX idx_lead_properties_lead_id ON lead_properties(lead_id);
+CREATE INDEX idx_lead_properties_property_id ON lead_properties(property_id);
+
+INSERT INTO lead_properties (lead_id, property_id, interest_level)
+SELECT id, property_id, 'UNDEFINED'
+FROM leads
+WHERE property_id IS NOT NULL
+ON CONFLICT (lead_id, property_id) DO NOTHING;


### PR DESCRIPTION
## Phase 3 — CRM Leads Module

### What's new
- **V6 migration**: `leads` + `lead_notes` tables
- **V7 migration**: `lead_events` audit log table  
- **V8 migration**: `lead_properties` junction table with interest level
- **Leads CRUD**: full REST API with tenant isolation, soft delete, pagination
- **Lead status workflow**: NEW → CONTACTED → QUALIFIED → WON/LOST
- **Lead notes**: add/list notes per lead
- **Lead events**: auto-logged audit trail (create, status change, assign, note, property link)
- **Broker assignment**: assign/unassign leads to users
- **Multiple properties of interest**: link multiple properties per lead with interest level (UNDEFINED/LOW/MEDIUM/HIGH), enriched with cover photo + price
- **Public lead capture**: `POST /api/v1/public/leads` (no auth, rate limited)
- **Lead stats**: `GET /api/v1/leads/stats` for dashboard metrics
- **User list**: `GET /api/v1/users` to list active tenant users for broker assignment

### Tech
- Spring Boot 3, Java 21, Flyway migrations, JPA
- All endpoints tenant-scoped via `TenantContext`