### PR TITLE
feat(phase-4): gestão de tarefas, tipos de tarefa

### DIFF
--- a/src/main/java/com/rinoimob/api/controller/TaskController.java
+++ b/src/main/java/com/rinoimob/api/controller/TaskController.java
@@ -1,0 +1,59 @@
+package com.rinoimob.api.controller;
+
+import com.rinoimob.context.TenantContext;
+import com.rinoimob.domain.dto.CreateTaskRequest;
+import com.rinoimob.domain.dto.TaskResponse;
+import com.rinoimob.domain.dto.UpdateTaskRequest;
+import com.rinoimob.service.TaskService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/tasks")
+@RequiredArgsConstructor
+public class TaskController {
+
+    private final TaskService taskService;
+
+    @GetMapping
+    public Page<TaskResponse> list(
+            @RequestParam(required = false) Boolean pending,
+            @RequestParam(required = false) UUID leadId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        UUID tenantId = UUID.fromString(TenantContext.getTenantId());
+        return taskService.list(tenantId, pending, leadId, page, size);
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public TaskResponse create(@Valid @RequestBody CreateTaskRequest req) {
+        UUID tenantId = UUID.fromString(TenantContext.getTenantId());
+        return taskService.create(tenantId, req);
+    }
+
+    @PutMapping("/{id}")
+    public TaskResponse update(@PathVariable UUID id, @RequestBody UpdateTaskRequest req) {
+        UUID tenantId = UUID.fromString(TenantContext.getTenantId());
+        return taskService.update(id, tenantId, req);
+    }
+
+    @PostMapping("/{id}/complete")
+    public TaskResponse complete(@PathVariable UUID id) {
+        UUID tenantId = UUID.fromString(TenantContext.getTenantId());
+        return taskService.complete(id, tenantId);
+    }
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@PathVariable UUID id) {
+        UUID tenantId = UUID.fromString(TenantContext.getTenantId());
+        taskService.delete(id, tenantId);
+    }
+}

--- a/src/main/java/com/rinoimob/api/controller/TaskTypeController.java
+++ b/src/main/java/com/rinoimob/api/controller/TaskTypeController.java
@@ -1,0 +1,48 @@
+package com.rinoimob.api.controller;
+
+import com.rinoimob.context.TenantContext;
+import com.rinoimob.domain.dto.CreateTaskTypeRequest;
+import com.rinoimob.domain.dto.TaskTypeResponse;
+import com.rinoimob.domain.dto.UpdateTaskTypeRequest;
+import com.rinoimob.service.TaskTypeService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/task-types")
+@RequiredArgsConstructor
+public class TaskTypeController {
+
+    private final TaskTypeService taskTypeService;
+
+    @GetMapping
+    public List<TaskTypeResponse> list() {
+        UUID tenantId = UUID.fromString(TenantContext.getTenantId());
+        return taskTypeService.list(tenantId);
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public TaskTypeResponse create(@Valid @RequestBody CreateTaskTypeRequest req) {
+        UUID tenantId = UUID.fromString(TenantContext.getTenantId());
+        return taskTypeService.create(tenantId, req);
+    }
+
+    @PutMapping("/{id}")
+    public TaskTypeResponse update(@PathVariable UUID id, @RequestBody UpdateTaskTypeRequest req) {
+        UUID tenantId = UUID.fromString(TenantContext.getTenantId());
+        return taskTypeService.update(id, tenantId, req);
+    }
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@PathVariable UUID id) {
+        UUID tenantId = UUID.fromString(TenantContext.getTenantId());
+        taskTypeService.delete(id, tenantId);
+    }
+}

--- a/src/main/java/com/rinoimob/domain/dto/CreateTaskRequest.java
+++ b/src/main/java/com/rinoimob/domain/dto/CreateTaskRequest.java
@@ -10,5 +10,6 @@ public record CreateTaskRequest(
         String description,
         UUID leadId,
         UUID assignedTo,
-        LocalDateTime dueAt
+        LocalDateTime dueAt,
+        UUID taskTypeId
 ) {}

--- a/src/main/java/com/rinoimob/domain/dto/CreateTaskRequest.java
+++ b/src/main/java/com/rinoimob/domain/dto/CreateTaskRequest.java
@@ -1,0 +1,14 @@
+package com.rinoimob.domain.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record CreateTaskRequest(
+        @NotBlank String title,
+        String description,
+        UUID leadId,
+        UUID assignedTo,
+        LocalDateTime dueAt
+) {}

--- a/src/main/java/com/rinoimob/domain/dto/CreateTaskTypeRequest.java
+++ b/src/main/java/com/rinoimob/domain/dto/CreateTaskTypeRequest.java
@@ -1,0 +1,10 @@
+package com.rinoimob.domain.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record CreateTaskTypeRequest(
+        @NotBlank String name,
+        String color,
+        String icon,
+        Integer position
+) {}

--- a/src/main/java/com/rinoimob/domain/dto/TaskResponse.java
+++ b/src/main/java/com/rinoimob/domain/dto/TaskResponse.java
@@ -17,5 +17,9 @@ public record TaskResponse(
         LocalDateTime completedAt,
         LocalDateTime createdAt,
         LocalDateTime updatedAt,
-        boolean overdue
+        boolean overdue,
+        UUID taskTypeId,
+        String taskTypeName,
+        String taskTypeColor,
+        String taskTypeIcon
 ) {}

--- a/src/main/java/com/rinoimob/domain/dto/TaskResponse.java
+++ b/src/main/java/com/rinoimob/domain/dto/TaskResponse.java
@@ -1,0 +1,21 @@
+package com.rinoimob.domain.dto;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record TaskResponse(
+        UUID id,
+        UUID tenantId,
+        UUID leadId,
+        String leadName,
+        UUID assignedTo,
+        String assignedToName,
+        String title,
+        String description,
+        LocalDateTime dueAt,
+        boolean completed,
+        LocalDateTime completedAt,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt,
+        boolean overdue
+) {}

--- a/src/main/java/com/rinoimob/domain/dto/TaskTypeResponse.java
+++ b/src/main/java/com/rinoimob/domain/dto/TaskTypeResponse.java
@@ -1,0 +1,12 @@
+package com.rinoimob.domain.dto;
+
+import java.util.UUID;
+
+public record TaskTypeResponse(
+        UUID id,
+        String name,
+        String color,
+        String icon,
+        int position,
+        boolean system
+) {}

--- a/src/main/java/com/rinoimob/domain/dto/UpdateTaskRequest.java
+++ b/src/main/java/com/rinoimob/domain/dto/UpdateTaskRequest.java
@@ -1,0 +1,12 @@
+package com.rinoimob.domain.dto;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record UpdateTaskRequest(
+        String title,
+        String description,
+        UUID leadId,
+        UUID assignedTo,
+        LocalDateTime dueAt
+) {}

--- a/src/main/java/com/rinoimob/domain/dto/UpdateTaskRequest.java
+++ b/src/main/java/com/rinoimob/domain/dto/UpdateTaskRequest.java
@@ -8,5 +8,6 @@ public record UpdateTaskRequest(
         String description,
         UUID leadId,
         UUID assignedTo,
-        LocalDateTime dueAt
+        LocalDateTime dueAt,
+        UUID taskTypeId
 ) {}

--- a/src/main/java/com/rinoimob/domain/dto/UpdateTaskTypeRequest.java
+++ b/src/main/java/com/rinoimob/domain/dto/UpdateTaskTypeRequest.java
@@ -1,0 +1,9 @@
+package com.rinoimob.domain.dto;
+
+public record UpdateTaskTypeRequest(
+        String name,
+        String color,
+        String icon,
+        Integer position,
+        Boolean active
+) {}

--- a/src/main/java/com/rinoimob/domain/entity/Task.java
+++ b/src/main/java/com/rinoimob/domain/entity/Task.java
@@ -1,0 +1,64 @@
+package com.rinoimob.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "tasks")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Task {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "tenant_id", nullable = false)
+    private UUID tenantId;
+
+    @Column(name = "lead_id")
+    private UUID leadId;
+
+    @Column(name = "assigned_to")
+    private UUID assignedTo;
+
+    @Column(nullable = false, length = 200)
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Column(name = "due_at")
+    private LocalDateTime dueAt;
+
+    @Column(name = "completed_at")
+    private LocalDateTime completedAt;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/rinoimob/domain/entity/Task.java
+++ b/src/main/java/com/rinoimob/domain/entity/Task.java
@@ -51,6 +51,9 @@ public class Task {
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
+    @Column(name = "task_type_id")
+    private UUID taskTypeId;
+
     @PrePersist
     protected void onCreate() {
         createdAt = LocalDateTime.now();

--- a/src/main/java/com/rinoimob/domain/entity/TaskType.java
+++ b/src/main/java/com/rinoimob/domain/entity/TaskType.java
@@ -1,0 +1,47 @@
+package com.rinoimob.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "task_types")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class TaskType {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "tenant_id")
+    private UUID tenantId;
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @Column(nullable = false, length = 20)
+    private String color;
+
+    @Column(length = 50)
+    private String icon;
+
+    @Column(nullable = false)
+    private int position;
+
+    @Column(nullable = false)
+    private boolean active;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/rinoimob/domain/repository/TaskRepository.java
+++ b/src/main/java/com/rinoimob/domain/repository/TaskRepository.java
@@ -1,0 +1,21 @@
+package com.rinoimob.domain.repository;
+
+import com.rinoimob.domain.entity.Task;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+public interface TaskRepository extends JpaRepository<Task, UUID> {
+    Page<Task> findByTenantIdAndDeletedAtIsNull(UUID tenantId, Pageable pageable);
+    Page<Task> findByTenantIdAndLeadIdAndDeletedAtIsNull(UUID tenantId, UUID leadId, Pageable pageable);
+    Page<Task> findByTenantIdAndAssignedToAndDeletedAtIsNull(UUID tenantId, UUID assignedTo, Pageable pageable);
+    Page<Task> findByTenantIdAndCompletedAtIsNullAndDeletedAtIsNull(UUID tenantId, Pageable pageable);
+    Page<Task> findByTenantIdAndCompletedAtIsNotNullAndDeletedAtIsNull(UUID tenantId, Pageable pageable);
+    List<Task> findByTenantIdAndLeadIdAndDeletedAtIsNull(UUID tenantId, UUID leadId);
+    long countByTenantIdAndCompletedAtIsNullAndDeletedAtIsNull(UUID tenantId);
+    long countByTenantIdAndDueAtBeforeAndCompletedAtIsNullAndDeletedAtIsNull(UUID tenantId, LocalDateTime now);
+}

--- a/src/main/java/com/rinoimob/domain/repository/TaskTypeRepository.java
+++ b/src/main/java/com/rinoimob/domain/repository/TaskTypeRepository.java
@@ -1,0 +1,17 @@
+package com.rinoimob.domain.repository;
+
+import com.rinoimob.domain.entity.TaskType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface TaskTypeRepository extends JpaRepository<TaskType, UUID> {
+
+    @Query("SELECT t FROM TaskType t WHERE (t.tenantId IS NULL OR t.tenantId = :tenantId) AND t.active = true ORDER BY t.position ASC, t.name ASC")
+    List<TaskType> findAvailableForTenant(@Param("tenantId") UUID tenantId);
+
+    List<TaskType> findByTenantIdAndActiveTrue(UUID tenantId);
+}

--- a/src/main/java/com/rinoimob/service/TaskService.java
+++ b/src/main/java/com/rinoimob/service/TaskService.java
@@ -4,8 +4,10 @@ import com.rinoimob.domain.dto.CreateTaskRequest;
 import com.rinoimob.domain.dto.TaskResponse;
 import com.rinoimob.domain.dto.UpdateTaskRequest;
 import com.rinoimob.domain.entity.Task;
+import com.rinoimob.domain.entity.TaskType;
 import com.rinoimob.domain.repository.LeadRepository;
 import com.rinoimob.domain.repository.TaskRepository;
+import com.rinoimob.domain.repository.TaskTypeRepository;
 import com.rinoimob.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -30,6 +32,7 @@ public class TaskService {
     private final TaskRepository taskRepository;
     private final LeadRepository leadRepository;
     private final UserRepository userRepository;
+    private final TaskTypeRepository taskTypeRepository;
 
     public Page<TaskResponse> list(UUID tenantId, Boolean pending, UUID leadId, int page, int size) {
         Pageable pageable = PageRequest.of(page, size, Sort.by("dueAt").ascending().and(Sort.by("createdAt").descending()));
@@ -59,6 +62,7 @@ public class TaskService {
                 .leadId(req.leadId())
                 .assignedTo(req.assignedTo())
                 .dueAt(req.dueAt())
+                .taskTypeId(req.taskTypeId())
                 .build();
         return toResponse(taskRepository.save(task));
     }
@@ -70,6 +74,7 @@ public class TaskService {
         if (req.leadId() != null) task.setLeadId(req.leadId());
         if (req.assignedTo() != null) task.setAssignedTo(req.assignedTo());
         if (req.dueAt() != null) task.setDueAt(req.dueAt());
+        if (req.taskTypeId() != null) task.setTaskTypeId(req.taskTypeId());
         return toResponse(taskRepository.save(task));
     }
 
@@ -103,11 +108,18 @@ public class TaskService {
         boolean overdue = task.getDueAt() != null
                 && task.getDueAt().isBefore(LocalDateTime.now())
                 && task.getCompletedAt() == null;
+        TaskType taskType = task.getTaskTypeId() != null
+                ? taskTypeRepository.findById(task.getTaskTypeId()).orElse(null)
+                : null;
         return new TaskResponse(
                 task.getId(), task.getTenantId(), task.getLeadId(), leadName,
                 task.getAssignedTo(), assignedToName, task.getTitle(), task.getDescription(),
                 task.getDueAt(), task.getCompletedAt() != null, task.getCompletedAt(),
-                task.getCreatedAt(), task.getUpdatedAt(), overdue
+                task.getCreatedAt(), task.getUpdatedAt(), overdue,
+                task.getTaskTypeId(),
+                taskType != null ? taskType.getName() : null,
+                taskType != null ? taskType.getColor() : null,
+                taskType != null ? taskType.getIcon() : null
         );
     }
 }

--- a/src/main/java/com/rinoimob/service/TaskService.java
+++ b/src/main/java/com/rinoimob/service/TaskService.java
@@ -1,0 +1,113 @@
+package com.rinoimob.service;
+
+import com.rinoimob.domain.dto.CreateTaskRequest;
+import com.rinoimob.domain.dto.TaskResponse;
+import com.rinoimob.domain.dto.UpdateTaskRequest;
+import com.rinoimob.domain.entity.Task;
+import com.rinoimob.domain.repository.LeadRepository;
+import com.rinoimob.domain.repository.TaskRepository;
+import com.rinoimob.domain.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class TaskService {
+
+    private final TaskRepository taskRepository;
+    private final LeadRepository leadRepository;
+    private final UserRepository userRepository;
+
+    public Page<TaskResponse> list(UUID tenantId, Boolean pending, UUID leadId, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by("dueAt").ascending().and(Sort.by("createdAt").descending()));
+        Page<Task> tasks;
+        if (leadId != null) {
+            tasks = taskRepository.findByTenantIdAndLeadIdAndDeletedAtIsNull(tenantId, leadId, pageable);
+        } else if (Boolean.TRUE.equals(pending)) {
+            tasks = taskRepository.findByTenantIdAndCompletedAtIsNullAndDeletedAtIsNull(tenantId, pageable);
+        } else if (Boolean.FALSE.equals(pending)) {
+            tasks = taskRepository.findByTenantIdAndCompletedAtIsNotNullAndDeletedAtIsNull(tenantId, pageable);
+        } else {
+            tasks = taskRepository.findByTenantIdAndDeletedAtIsNull(tenantId, pageable);
+        }
+        return tasks.map(this::toResponse);
+    }
+
+    public List<TaskResponse> listByLead(UUID tenantId, UUID leadId) {
+        return taskRepository.findByTenantIdAndLeadIdAndDeletedAtIsNull(tenantId, leadId)
+                .stream().map(this::toResponse).collect(Collectors.toList());
+    }
+
+    public TaskResponse create(UUID tenantId, CreateTaskRequest req) {
+        Task task = Task.builder()
+                .tenantId(tenantId)
+                .title(req.title())
+                .description(req.description())
+                .leadId(req.leadId())
+                .assignedTo(req.assignedTo())
+                .dueAt(req.dueAt())
+                .build();
+        return toResponse(taskRepository.save(task));
+    }
+
+    public TaskResponse update(UUID id, UUID tenantId, UpdateTaskRequest req) {
+        Task task = findTask(id, tenantId);
+        if (req.title() != null) task.setTitle(req.title());
+        if (req.description() != null) task.setDescription(req.description());
+        if (req.leadId() != null) task.setLeadId(req.leadId());
+        if (req.assignedTo() != null) task.setAssignedTo(req.assignedTo());
+        if (req.dueAt() != null) task.setDueAt(req.dueAt());
+        return toResponse(taskRepository.save(task));
+    }
+
+    public TaskResponse complete(UUID id, UUID tenantId) {
+        Task task = findTask(id, tenantId);
+        task.setCompletedAt(task.getCompletedAt() == null ? LocalDateTime.now() : null);
+        return toResponse(taskRepository.save(task));
+    }
+
+    public void delete(UUID id, UUID tenantId) {
+        Task task = findTask(id, tenantId);
+        task.setDeletedAt(LocalDateTime.now());
+        taskRepository.save(task);
+    }
+
+    private Task findTask(UUID id, UUID tenantId) {
+        return taskRepository.findById(id)
+                .filter(t -> t.getTenantId().equals(tenantId) && t.getDeletedAt() == null)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Task not found"));
+    }
+
+    private TaskResponse toResponse(Task task) {
+        String leadName = task.getLeadId() != null
+                ? leadRepository.findById(task.getLeadId()).map(l -> l.getName()).orElse(null)
+                : null;
+        String assignedToName = task.getAssignedTo() != null
+                ? userRepository.findById(task.getAssignedTo())
+                        .map(u -> (u.getFirstName() != null ? u.getFirstName() : "") + " " + (u.getLastName() != null ? u.getLastName() : ""))
+                        .map(String::trim).orElse(null)
+                : null;
+        boolean overdue = task.getDueAt() != null
+                && task.getDueAt().isBefore(LocalDateTime.now())
+                && task.getCompletedAt() == null;
+        return new TaskResponse(
+                task.getId(), task.getTenantId(), task.getLeadId(), leadName,
+                task.getAssignedTo(), assignedToName, task.getTitle(), task.getDescription(),
+                task.getDueAt(), task.getCompletedAt() != null, task.getCompletedAt(),
+                task.getCreatedAt(), task.getUpdatedAt(), overdue
+        );
+    }
+}

--- a/src/main/java/com/rinoimob/service/TaskTypeService.java
+++ b/src/main/java/com/rinoimob/service/TaskTypeService.java
@@ -1,0 +1,64 @@
+package com.rinoimob.service;
+
+import com.rinoimob.domain.dto.CreateTaskTypeRequest;
+import com.rinoimob.domain.dto.TaskTypeResponse;
+import com.rinoimob.domain.dto.UpdateTaskTypeRequest;
+import com.rinoimob.domain.entity.TaskType;
+import com.rinoimob.domain.repository.TaskTypeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class TaskTypeService {
+
+    private final TaskTypeRepository taskTypeRepository;
+
+    public List<TaskTypeResponse> list(UUID tenantId) {
+        return taskTypeRepository.findAvailableForTenant(tenantId)
+                .stream().map(this::toResponse).collect(Collectors.toList());
+    }
+
+    public TaskTypeResponse create(UUID tenantId, CreateTaskTypeRequest req) {
+        TaskType type = new TaskType();
+        type.setTenantId(tenantId);
+        type.setName(req.name());
+        type.setColor(req.color() != null ? req.color() : "#6366f1");
+        type.setIcon(req.icon());
+        type.setPosition(req.position() != null ? req.position() : 99);
+        type.setActive(true);
+        return toResponse(taskTypeRepository.save(type));
+    }
+
+    public TaskTypeResponse update(UUID id, UUID tenantId, UpdateTaskTypeRequest req) {
+        TaskType type = taskTypeRepository.findById(id)
+                .filter(t -> tenantId.equals(t.getTenantId()))
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Task type not found or not editable"));
+        if (req.name() != null) type.setName(req.name());
+        if (req.color() != null) type.setColor(req.color());
+        if (req.icon() != null) type.setIcon(req.icon());
+        if (req.position() != null) type.setPosition(req.position());
+        if (req.active() != null) type.setActive(req.active());
+        return toResponse(taskTypeRepository.save(type));
+    }
+
+    public void delete(UUID id, UUID tenantId) {
+        TaskType type = taskTypeRepository.findById(id)
+                .filter(t -> tenantId.equals(t.getTenantId()))
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Task type not found or not deletable"));
+        type.setActive(false);
+        taskTypeRepository.save(type);
+    }
+
+    private TaskTypeResponse toResponse(TaskType t) {
+        return new TaskTypeResponse(t.getId(), t.getName(), t.getColor(), t.getIcon(), t.getPosition(), t.getTenantId() == null);
+    }
+}

--- a/src/main/resources/db/migration/V10__task_types.sql
+++ b/src/main/resources/db/migration/V10__task_types.sql
@@ -1,0 +1,22 @@
+CREATE TABLE task_types (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id UUID REFERENCES tenants(id) ON DELETE CASCADE,  -- NULL = system default
+    name VARCHAR(100) NOT NULL,
+    color VARCHAR(20) NOT NULL DEFAULT '#6366f1',
+    icon VARCHAR(50),          -- icon name/identifier for frontend
+    position INT NOT NULL DEFAULT 0,
+    active BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+-- System defaults (tenant_id = NULL)
+INSERT INTO task_types (id, tenant_id, name, color, icon, position) VALUES
+  (gen_random_uuid(), NULL, 'Visita',     '#8b5cf6', 'home',      1),
+  (gen_random_uuid(), NULL, 'Ligação',    '#3b82f6', 'phone',     2),
+  (gen_random_uuid(), NULL, 'Reunião',    '#f59e0b', 'users',     3),
+  (gen_random_uuid(), NULL, 'Follow-up',  '#10b981', 'refresh',   4),
+  (gen_random_uuid(), NULL, 'Email',      '#6366f1', 'mail',      5),
+  (gen_random_uuid(), NULL, 'Outro',      '#64748b', 'dots',      6);
+
+-- Add task_type_id to tasks (nullable for backward compat)
+ALTER TABLE tasks ADD COLUMN task_type_id UUID REFERENCES task_types(id) ON DELETE SET NULL;

--- a/src/main/resources/db/migration/V9__tasks.sql
+++ b/src/main/resources/db/migration/V9__tasks.sql
@@ -1,0 +1,17 @@
+CREATE TABLE tasks (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id UUID NOT NULL REFERENCES tenants(id),
+    lead_id UUID REFERENCES leads(id) ON DELETE SET NULL,
+    assigned_to UUID REFERENCES users(id) ON DELETE SET NULL,
+    title VARCHAR(200) NOT NULL,
+    description TEXT,
+    due_at TIMESTAMP,
+    completed_at TIMESTAMP,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    deleted_at TIMESTAMP
+);
+
+CREATE INDEX idx_tasks_tenant_id ON tasks(tenant_id);
+CREATE INDEX idx_tasks_lead_id ON tasks(lead_id);
+CREATE INDEX idx_tasks_assigned_to ON tasks(assigned_to);


### PR DESCRIPTION
## Phase 4 — Backend: Gestão de Tarefas

### Migrations
- **V9**: tabela `tasks` com FK para leads, users e tenants; 3 índices
- **V10**: tabela `task_types` com 6 tipos padrão do sistema (tenant_id NULL = sistema); FK `task_type_id` em `tasks`

### Entities & Repositories
- `Task` (JPA entity com `@PrePersist`/`@PreUpdate`)
- `TaskType` (JPA entity)
- `TaskRepository` — 8 derived queries (por tenant, lead, pending, overdue)
- `TaskTypeRepository` — `findAvailableForTenant` retorna sistema + próprios do tenant

### Services & Controllers
- `TaskService`: CRUD + toggle complete + filtro pending/leadId + enriquecimento (leadName, assignedToName, overdue flag)
- `TaskController`: `GET/POST/PUT/DELETE /api/v1/tasks` + `POST /api/v1/tasks/{id}/complete`
- `TaskTypeService`: guard de ownership (tenant só edita/deleta os próprios)
- `TaskTypeController`: `GET/POST/PUT/DELETE /api/v1/task-types`

### DTOs
- `CreateTaskRequest`, `UpdateTaskRequest`, `TaskResponse` (com overdue, leadName, typeName/color/icon)
- `CreateTaskTypeRequest`, `UpdateTaskTypeRequest`, `TaskTypeResponse`