### PR TITLE
feat(whatsapp): Phase 4.5 — WhatsApp backend via Evolution API

### DIFF
--- a/src/main/java/com/rinoimob/api/client/EvolutionApiClient.java
+++ b/src/main/java/com/rinoimob/api/client/EvolutionApiClient.java
@@ -1,0 +1,96 @@
+package com.rinoimob.api.client;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+@Component
+public class EvolutionApiClient {
+
+    @Value("${evolution.api.url:http://localhost:8085}")
+    private String baseUrl;
+
+    @Value("${evolution.api.key:changeme-evolution-apikey}")
+    private String apiKey;
+
+    private final RestTemplate restTemplate = new RestTemplate();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private HttpHeaders headers() {
+        HttpHeaders h = new HttpHeaders();
+        h.set("apikey", apiKey);
+        h.setContentType(MediaType.APPLICATION_JSON);
+        return h;
+    }
+
+    /** Creates a new instance in Evolution API with RabbitMQ enabled */
+    public void createInstance(String instanceName) {
+        Map<String, Object> body = Map.of(
+            "instanceName", instanceName,
+            "integration", "WHATSAPP-BAILEYS",
+            "qrcode", false,
+            "groupsIgnore", true,
+            "alwaysOnline", false,
+            "readMessages", true
+        );
+        HttpEntity<Map<String, Object>> request = new HttpEntity<>(body, headers());
+        restTemplate.exchange(baseUrl + "/instance/create", HttpMethod.POST, request, Map.class);
+    }
+
+    /** Gets QR code / pairing code for an instance */
+    @SuppressWarnings("unchecked")
+    public Map<String, Object> getQrCode(String instanceName) {
+        HttpEntity<Void> request = new HttpEntity<>(headers());
+        ResponseEntity<Map> response = restTemplate.exchange(
+            baseUrl + "/instance/connect/" + instanceName,
+            HttpMethod.GET, request, Map.class);
+        return response.getBody();
+    }
+
+    /** Gets current connection state */
+    @SuppressWarnings("unchecked")
+    public String getConnectionState(String instanceName) {
+        try {
+            HttpEntity<Void> request = new HttpEntity<>(headers());
+            ResponseEntity<Map> response = restTemplate.exchange(
+                baseUrl + "/instance/connectionState/" + instanceName,
+                HttpMethod.GET, request, Map.class);
+            Map<String, Object> body = response.getBody();
+            if (body != null && body.get("instance") instanceof Map) {
+                Map<String, Object> inst = (Map<String, Object>) body.get("instance");
+                return (String) inst.get("state"); // open | close | connecting
+            }
+        } catch (Exception ignored) {}
+        return "close";
+    }
+
+    /** Sends a plain text message */
+    @SuppressWarnings("unchecked")
+    public String sendText(String instanceName, String toNumber, String text) {
+        Map<String, Object> body = Map.of("number", toNumber, "text", text);
+        HttpEntity<Map<String, Object>> request = new HttpEntity<>(body, headers());
+        ResponseEntity<Map> response = restTemplate.exchange(
+            baseUrl + "/message/sendText/" + instanceName,
+            HttpMethod.POST, request, Map.class);
+        Map<String, Object> resp = response.getBody();
+        if (resp != null && resp.get("key") instanceof Map) {
+            Map<String, Object> key = (Map<String, Object>) resp.get("key");
+            return (String) key.get("id");
+        }
+        return null;
+    }
+
+    /** Deletes an instance from Evolution API */
+    public void deleteInstance(String instanceName) {
+        try {
+            HttpEntity<Void> request = new HttpEntity<>(headers());
+            restTemplate.exchange(
+                baseUrl + "/instance/delete/" + instanceName,
+                HttpMethod.DELETE, request, Void.class);
+        } catch (Exception ignored) {}
+    }
+}

--- a/src/main/java/com/rinoimob/api/controller/WhatsappInstanceController.java
+++ b/src/main/java/com/rinoimob/api/controller/WhatsappInstanceController.java
@@ -1,0 +1,46 @@
+package com.rinoimob.api.controller;
+
+import com.rinoimob.domain.dto.CreateWhatsappInstanceRequest;
+import com.rinoimob.domain.dto.WhatsappInstanceResponse;
+import com.rinoimob.domain.dto.WhatsappQrCodeResponse;
+import com.rinoimob.service.WhatsappInstanceService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/whatsapp/instances")
+@RequiredArgsConstructor
+public class WhatsappInstanceController {
+
+    private final WhatsappInstanceService service;
+
+    @GetMapping
+    public ResponseEntity<List<WhatsappInstanceResponse>> list() {
+        return ResponseEntity.ok(service.listForTenant());
+    }
+
+    @PostMapping
+    public ResponseEntity<WhatsappInstanceResponse> create(@RequestBody CreateWhatsappInstanceRequest req) {
+        return ResponseEntity.status(201).body(service.create(req));
+    }
+
+    @GetMapping("/{id}/qrcode")
+    public ResponseEntity<WhatsappQrCodeResponse> qrCode(@PathVariable UUID id) {
+        return ResponseEntity.ok(service.getQrCode(id));
+    }
+
+    @GetMapping("/{id}/status")
+    public ResponseEntity<WhatsappInstanceResponse> status(@PathVariable UUID id) {
+        return ResponseEntity.ok(service.getStatus(id));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable UUID id) {
+        service.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/rinoimob/api/controller/WhatsappMessageController.java
+++ b/src/main/java/com/rinoimob/api/controller/WhatsappMessageController.java
@@ -1,0 +1,34 @@
+package com.rinoimob.api.controller;
+
+import com.rinoimob.domain.dto.SendWhatsappMessageRequest;
+import com.rinoimob.domain.dto.WhatsappMessageResponse;
+import com.rinoimob.service.WhatsappMessageService;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/whatsapp/leads")
+@RequiredArgsConstructor
+public class WhatsappMessageController {
+
+    private final WhatsappMessageService service;
+
+    @GetMapping("/{leadId}/messages")
+    public ResponseEntity<List<WhatsappMessageResponse>> getMessages(@PathVariable UUID leadId) {
+        return ResponseEntity.ok(service.getMessagesForLead(leadId));
+    }
+
+    @PostMapping("/{leadId}/messages")
+    public ResponseEntity<WhatsappMessageResponse> send(
+            @PathVariable UUID leadId,
+            @RequestBody SendWhatsappMessageRequest req,
+            HttpServletRequest httpRequest) {
+        UUID userId = (UUID) httpRequest.getAttribute("userId");
+        return ResponseEntity.status(201).body(service.send(leadId, req, userId));
+    }
+}

--- a/src/main/java/com/rinoimob/config/WhatsappRabbitMQConfig.java
+++ b/src/main/java/com/rinoimob/config/WhatsappRabbitMQConfig.java
@@ -1,0 +1,38 @@
+package com.rinoimob.config;
+
+import org.springframework.amqp.core.*;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class WhatsappRabbitMQConfig {
+
+    public static final String EVOLUTION_EXCHANGE = "evolution";
+    public static final String MESSAGES_QUEUE = "rinoimob.evolution.messages";
+    public static final String CONNECTION_QUEUE = "rinoimob.evolution.connection";
+
+    @Bean
+    public TopicExchange evolutionExchange() {
+        return ExchangeBuilder.topicExchange(EVOLUTION_EXCHANGE).durable(true).build();
+    }
+
+    @Bean
+    public Queue messagesQueue() {
+        return QueueBuilder.durable(MESSAGES_QUEUE).build();
+    }
+
+    @Bean
+    public Queue connectionQueue() {
+        return QueueBuilder.durable(CONNECTION_QUEUE).build();
+    }
+
+    @Bean
+    public Binding messagesBinding(Queue messagesQueue, TopicExchange evolutionExchange) {
+        return BindingBuilder.bind(messagesQueue).to(evolutionExchange).with("*.MESSAGES_UPSERT");
+    }
+
+    @Bean
+    public Binding connectionBinding(Queue connectionQueue, TopicExchange evolutionExchange) {
+        return BindingBuilder.bind(connectionQueue).to(evolutionExchange).with("*.CONNECTION_UPDATE");
+    }
+}

--- a/src/main/java/com/rinoimob/domain/dto/CreateWhatsappInstanceRequest.java
+++ b/src/main/java/com/rinoimob/domain/dto/CreateWhatsappInstanceRequest.java
@@ -1,0 +1,13 @@
+package com.rinoimob.domain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateWhatsappInstanceRequest {
+    private String displayName;
+    private String phoneNumber; // optional at creation time
+}

--- a/src/main/java/com/rinoimob/domain/dto/SendWhatsappMessageRequest.java
+++ b/src/main/java/com/rinoimob/domain/dto/SendWhatsappMessageRequest.java
@@ -1,0 +1,15 @@
+package com.rinoimob.domain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class SendWhatsappMessageRequest {
+    private UUID instanceId;
+    private String text;
+}

--- a/src/main/java/com/rinoimob/domain/dto/WhatsappInstanceResponse.java
+++ b/src/main/java/com/rinoimob/domain/dto/WhatsappInstanceResponse.java
@@ -1,0 +1,20 @@
+package com.rinoimob.domain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class WhatsappInstanceResponse {
+    private UUID id;
+    private String instanceName;
+    private String displayName;
+    private String phoneNumber;
+    private String status;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/rinoimob/domain/dto/WhatsappMessageResponse.java
+++ b/src/main/java/com/rinoimob/domain/dto/WhatsappMessageResponse.java
@@ -1,0 +1,23 @@
+package com.rinoimob.domain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class WhatsappMessageResponse {
+    private UUID id;
+    private String direction; // INBOUND | OUTBOUND
+    private String content;
+    private String status;
+    private UUID instanceId;
+    private String instanceDisplayName;
+    private UUID sentByUserId;
+    private String sentByUserName; // first + last
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/rinoimob/domain/dto/WhatsappQrCodeResponse.java
+++ b/src/main/java/com/rinoimob/domain/dto/WhatsappQrCodeResponse.java
@@ -1,0 +1,14 @@
+package com.rinoimob.domain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class WhatsappQrCodeResponse {
+    private String pairingCode;
+    private String code; // base64 QR
+    private String status; // current instance status
+}

--- a/src/main/java/com/rinoimob/domain/entity/WhatsappInstance.java
+++ b/src/main/java/com/rinoimob/domain/entity/WhatsappInstance.java
@@ -1,0 +1,52 @@
+package com.rinoimob.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "whatsapp_instances")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class WhatsappInstance {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "tenant_id", nullable = false)
+    private UUID tenantId;
+
+    @Column(name = "instance_name", nullable = false, unique = true)
+    private String instanceName;
+
+    @Column(name = "display_name", nullable = false)
+    private String displayName;
+
+    @Column(name = "phone_number")
+    private String phoneNumber;
+
+    @Column(nullable = false)
+    private String status = "DISCONNECTED"; // DISCONNECTED | CONNECTING | CONNECTED
+
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/rinoimob/domain/entity/WhatsappMessage.java
+++ b/src/main/java/com/rinoimob/domain/entity/WhatsappMessage.java
@@ -1,0 +1,53 @@
+package com.rinoimob.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "whatsapp_messages")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class WhatsappMessage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "tenant_id", nullable = false)
+    private UUID tenantId;
+
+    @Column(name = "lead_id")
+    private UUID leadId;
+
+    @Column(name = "instance_id", nullable = false)
+    private UUID instanceId;
+
+    @Column(nullable = false)
+    private String direction; // INBOUND | OUTBOUND
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Column(name = "sent_by_user_id")
+    private UUID sentByUserId;
+
+    @Column(name = "external_message_id")
+    private String externalMessageId;
+
+    @Column(nullable = false)
+    private String status = "SENT";
+
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/rinoimob/domain/repository/LeadRepository.java
+++ b/src/main/java/com/rinoimob/domain/repository/LeadRepository.java
@@ -30,4 +30,6 @@ public interface LeadRepository extends JpaRepository<Lead, UUID> {
 
     @Query("SELECT COUNT(l) FROM Lead l WHERE l.tenantId = :tenantId AND l.deletedAt IS NULL AND l.createdAt >= :since")
     long countByTenantIdAndCreatedAtAfterAndDeletedAtIsNull(UUID tenantId, @Param("since") java.time.LocalDateTime since);
+
+    List<Lead> findByTenantIdAndDeletedAtIsNull(UUID tenantId);
 }

--- a/src/main/java/com/rinoimob/domain/repository/WhatsappInstanceRepository.java
+++ b/src/main/java/com/rinoimob/domain/repository/WhatsappInstanceRepository.java
@@ -1,0 +1,19 @@
+package com.rinoimob.domain.repository;
+
+import com.rinoimob.domain.entity.WhatsappInstance;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface WhatsappInstanceRepository extends JpaRepository<WhatsappInstance, UUID> {
+
+    List<WhatsappInstance> findByTenantIdOrderByCreatedAtAsc(UUID tenantId);
+
+    Optional<WhatsappInstance> findByInstanceName(String instanceName);
+
+    Optional<WhatsappInstance> findByIdAndTenantId(UUID id, UUID tenantId);
+}

--- a/src/main/java/com/rinoimob/domain/repository/WhatsappMessageRepository.java
+++ b/src/main/java/com/rinoimob/domain/repository/WhatsappMessageRepository.java
@@ -1,0 +1,16 @@
+package com.rinoimob.domain.repository;
+
+import com.rinoimob.domain.entity.WhatsappMessage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface WhatsappMessageRepository extends JpaRepository<WhatsappMessage, UUID> {
+
+    List<WhatsappMessage> findByLeadIdOrderByCreatedAtAsc(UUID leadId);
+
+    List<WhatsappMessage> findByTenantIdAndLeadIdIsNullOrderByCreatedAtDesc(UUID tenantId);
+}

--- a/src/main/java/com/rinoimob/messaging/consumer/WhatsappRabbitMqConsumer.java
+++ b/src/main/java/com/rinoimob/messaging/consumer/WhatsappRabbitMqConsumer.java
@@ -1,0 +1,115 @@
+package com.rinoimob.messaging.consumer;
+
+import com.rinoimob.config.WhatsappRabbitMQConfig;
+import com.rinoimob.domain.entity.WhatsappMessage;
+import com.rinoimob.domain.repository.LeadRepository;
+import com.rinoimob.domain.repository.WhatsappInstanceRepository;
+import com.rinoimob.domain.repository.WhatsappMessageRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.logging.Logger;
+
+@Component
+@RequiredArgsConstructor
+public class WhatsappRabbitMqConsumer {
+
+    private static final Logger log = Logger.getLogger(WhatsappRabbitMqConsumer.class.getName());
+
+    private final WhatsappInstanceRepository instanceRepo;
+    private final WhatsappMessageRepository messageRepo;
+    private final LeadRepository leadRepo;
+
+    @RabbitListener(queues = WhatsappRabbitMQConfig.MESSAGES_QUEUE)
+    @SuppressWarnings("unchecked")
+    public void handleMessageUpsert(Map<String, Object> payload) {
+        try {
+            String instanceName = (String) payload.get("instance");
+            if (instanceName == null) return;
+
+            instanceRepo.findByInstanceName(instanceName).ifPresent(instance -> {
+                Object dataObj = payload.get("data");
+                if (!(dataObj instanceof Map)) return;
+                Map<String, Object> data = (Map<String, Object>) dataObj;
+
+                Object keyObj = data.get("key");
+                if (!(keyObj instanceof Map)) return;
+                Map<String, Object> key = (Map<String, Object>) keyObj;
+
+                // Skip messages sent by us
+                if (Boolean.TRUE.equals(key.get("fromMe"))) return;
+
+                String remoteJid = (String) key.get("remoteJid");
+                if (remoteJid == null || remoteJid.contains("@g.us")) return; // skip groups
+
+                String fromNumber = remoteJid.replace("@s.whatsapp.net", "").replaceAll("\\D", "");
+
+                String text = extractText(data);
+                if (text == null || text.isBlank()) return;
+
+                // Match lead by phone within the tenant
+                UUID leadId = leadRepo.findByTenantIdAndDeletedAtIsNull(instance.getTenantId()).stream()
+                    .filter(l -> l.getPhone() != null && (
+                        l.getPhone().replaceAll("\\D", "").endsWith(fromNumber) ||
+                        fromNumber.endsWith(l.getPhone().replaceAll("\\D", ""))))
+                    .findFirst()
+                    .map(l -> l.getId())
+                    .orElse(null);
+
+                WhatsappMessage msg = new WhatsappMessage();
+                msg.setTenantId(instance.getTenantId());
+                msg.setLeadId(leadId);
+                msg.setInstanceId(instance.getId());
+                msg.setDirection("INBOUND");
+                msg.setContent(text);
+                msg.setStatus("RECEIVED");
+                messageRepo.save(msg);
+            });
+        } catch (Exception e) {
+            log.warning("Error processing WhatsApp message: " + e.getMessage());
+        }
+    }
+
+    @RabbitListener(queues = WhatsappRabbitMQConfig.CONNECTION_QUEUE)
+    @SuppressWarnings("unchecked")
+    public void handleConnectionUpdate(Map<String, Object> payload) {
+        try {
+            String instanceName = (String) payload.get("instance");
+            if (instanceName == null) return;
+
+            Object dataObj = payload.get("data");
+            if (!(dataObj instanceof Map)) return;
+            Map<String, Object> data = (Map<String, Object>) dataObj;
+            String state = (String) data.get("state"); // open | close | connecting
+
+            instanceRepo.findByInstanceName(instanceName).ifPresent(instance -> {
+                String newStatus = switch (state != null ? state : "") {
+                    case "open" -> "CONNECTED";
+                    case "connecting" -> "CONNECTING";
+                    default -> "DISCONNECTED";
+                };
+                instance.setStatus(newStatus);
+                instanceRepo.save(instance);
+            });
+        } catch (Exception e) {
+            log.warning("Error processing connection update: " + e.getMessage());
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private String extractText(Map<String, Object> data) {
+        Object msgObj = data.get("message");
+        if (!(msgObj instanceof Map)) return null;
+        Map<String, Object> message = (Map<String, Object>) msgObj;
+        // Plain text
+        if (message.get("conversation") instanceof String s) return s;
+        // Extended text
+        if (message.get("extendedTextMessage") instanceof Map ext) {
+            return (String) ((Map<String, Object>) ext).get("text");
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/rinoimob/service/WhatsappInstanceService.java
+++ b/src/main/java/com/rinoimob/service/WhatsappInstanceService.java
@@ -1,0 +1,109 @@
+package com.rinoimob.service;
+
+import com.rinoimob.api.client.EvolutionApiClient;
+import com.rinoimob.context.TenantContext;
+import com.rinoimob.domain.dto.CreateWhatsappInstanceRequest;
+import com.rinoimob.domain.dto.WhatsappInstanceResponse;
+import com.rinoimob.domain.dto.WhatsappQrCodeResponse;
+import com.rinoimob.domain.entity.Tenant;
+import com.rinoimob.domain.entity.WhatsappInstance;
+import com.rinoimob.domain.repository.TenantRepository;
+import com.rinoimob.domain.repository.WhatsappInstanceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class WhatsappInstanceService {
+
+    private final WhatsappInstanceRepository instanceRepo;
+    private final TenantRepository tenantRepo;
+    private final EvolutionApiClient evolutionClient;
+
+    public List<WhatsappInstanceResponse> listForTenant() {
+        UUID tenantId = UUID.fromString(TenantContext.getTenantId());
+        return instanceRepo.findByTenantIdOrderByCreatedAtAsc(tenantId)
+            .stream().map(this::toResponse).toList();
+    }
+
+    public WhatsappInstanceResponse create(CreateWhatsappInstanceRequest req) {
+        UUID tenantId = UUID.fromString(TenantContext.getTenantId());
+        Tenant tenant = tenantRepo.findById(tenantId)
+            .orElseThrow(() -> new RuntimeException("Tenant not found"));
+
+        // instanceName: subdomain + short random suffix to ensure uniqueness
+        String instanceName = tenant.getSubdomain() + "-" + UUID.randomUUID().toString().substring(0, 8);
+
+        WhatsappInstance instance = new WhatsappInstance();
+        instance.setTenantId(tenantId);
+        instance.setInstanceName(instanceName);
+        instance.setDisplayName(req.getDisplayName());
+        instance.setPhoneNumber(req.getPhoneNumber());
+        instance.setStatus("DISCONNECTED");
+        instance = instanceRepo.save(instance);
+
+        // Register in Evolution API (fire-and-forget on failure)
+        try {
+            evolutionClient.createInstance(instanceName);
+            instance.setStatus("CONNECTING");
+            instance = instanceRepo.save(instance);
+        } catch (Exception e) {
+            // log but don't fail — user can retry via QR code endpoint
+        }
+
+        return toResponse(instance);
+    }
+
+    public WhatsappQrCodeResponse getQrCode(UUID instanceId) {
+        UUID tenantId = UUID.fromString(TenantContext.getTenantId());
+        WhatsappInstance instance = instanceRepo.findByIdAndTenantId(instanceId, tenantId)
+            .orElseThrow(() -> new RuntimeException("Instance not found"));
+
+        WhatsappQrCodeResponse resp = new WhatsappQrCodeResponse();
+        resp.setStatus(instance.getStatus());
+        try {
+            Map<String, Object> qr = evolutionClient.getQrCode(instance.getInstanceName());
+            resp.setPairingCode((String) qr.get("pairingCode"));
+            resp.setCode((String) qr.get("code")); // base64 QR or URL
+        } catch (Exception e) {
+            // QR not available yet
+        }
+        return resp;
+    }
+
+    public WhatsappInstanceResponse getStatus(UUID instanceId) {
+        UUID tenantId = UUID.fromString(TenantContext.getTenantId());
+        WhatsappInstance instance = instanceRepo.findByIdAndTenantId(instanceId, tenantId)
+            .orElseThrow(() -> new RuntimeException("Instance not found"));
+
+        // Sync status from Evolution API
+        String state = evolutionClient.getConnectionState(instance.getInstanceName());
+        String newStatus = switch (state) {
+            case "open" -> "CONNECTED";
+            case "connecting" -> "CONNECTING";
+            default -> "DISCONNECTED";
+        };
+        if (!newStatus.equals(instance.getStatus())) {
+            instance.setStatus(newStatus);
+            instanceRepo.save(instance);
+        }
+        return toResponse(instance);
+    }
+
+    public void delete(UUID instanceId) {
+        UUID tenantId = UUID.fromString(TenantContext.getTenantId());
+        WhatsappInstance instance = instanceRepo.findByIdAndTenantId(instanceId, tenantId)
+            .orElseThrow(() -> new RuntimeException("Instance not found"));
+        evolutionClient.deleteInstance(instance.getInstanceName());
+        instanceRepo.delete(instance);
+    }
+
+    public WhatsappInstanceResponse toResponse(WhatsappInstance i) {
+        return new WhatsappInstanceResponse(i.getId(), i.getInstanceName(),
+            i.getDisplayName(), i.getPhoneNumber(), i.getStatus(), i.getCreatedAt());
+    }
+}

--- a/src/main/java/com/rinoimob/service/WhatsappMessageService.java
+++ b/src/main/java/com/rinoimob/service/WhatsappMessageService.java
@@ -1,0 +1,96 @@
+package com.rinoimob.service;
+
+import com.rinoimob.api.client.EvolutionApiClient;
+import com.rinoimob.context.TenantContext;
+import com.rinoimob.domain.dto.SendWhatsappMessageRequest;
+import com.rinoimob.domain.dto.WhatsappMessageResponse;
+import com.rinoimob.domain.entity.Lead;
+import com.rinoimob.domain.entity.WhatsappInstance;
+import com.rinoimob.domain.entity.WhatsappMessage;
+import com.rinoimob.domain.repository.LeadRepository;
+import com.rinoimob.domain.repository.UserRepository;
+import com.rinoimob.domain.repository.WhatsappInstanceRepository;
+import com.rinoimob.domain.repository.WhatsappMessageRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class WhatsappMessageService {
+
+    private final WhatsappMessageRepository messageRepo;
+    private final WhatsappInstanceRepository instanceRepo;
+    private final LeadRepository leadRepo;
+    private final UserRepository userRepo;
+    private final EvolutionApiClient evolutionClient;
+
+    public List<WhatsappMessageResponse> getMessagesForLead(UUID leadId) {
+        UUID tenantId = UUID.fromString(TenantContext.getTenantId());
+        // Verify lead belongs to tenant
+        leadRepo.findByIdAndTenantIdAndDeletedAtIsNull(leadId, tenantId)
+            .orElseThrow(() -> new RuntimeException("Lead not found"));
+        return messageRepo.findByLeadIdOrderByCreatedAtAsc(leadId)
+            .stream().map(this::toResponse).toList();
+    }
+
+    public WhatsappMessageResponse send(UUID leadId, SendWhatsappMessageRequest req, UUID userId) {
+        UUID tenantId = UUID.fromString(TenantContext.getTenantId());
+
+        Lead lead = leadRepo.findByIdAndTenantIdAndDeletedAtIsNull(leadId, tenantId)
+            .orElseThrow(() -> new RuntimeException("Lead not found"));
+
+        if (lead.getPhone() == null || lead.getPhone().isBlank()) {
+            throw new RuntimeException("Lead has no phone number");
+        }
+
+        WhatsappInstance instance = instanceRepo.findByIdAndTenantId(req.getInstanceId(), tenantId)
+            .orElseThrow(() -> new RuntimeException("Instance not found"));
+
+        if (!"CONNECTED".equals(instance.getStatus())) {
+            throw new RuntimeException("WhatsApp instance is not connected");
+        }
+
+        // Normalize phone: keep digits only, ensure country code
+        String toNumber = lead.getPhone().replaceAll("\\D", "");
+
+        String externalId = evolutionClient.sendText(instance.getInstanceName(), toNumber, req.getText());
+
+        WhatsappMessage message = new WhatsappMessage();
+        message.setTenantId(tenantId);
+        message.setLeadId(leadId);
+        message.setInstanceId(instance.getId());
+        message.setDirection("OUTBOUND");
+        message.setContent(req.getText());
+        message.setSentByUserId(userId);
+        message.setExternalMessageId(externalId);
+        message.setStatus("SENT");
+        message = messageRepo.save(message);
+
+        return toResponse(message);
+    }
+
+    public WhatsappMessageResponse toResponse(WhatsappMessage m) {
+        WhatsappMessageResponse r = new WhatsappMessageResponse();
+        r.setId(m.getId());
+        r.setDirection(m.getDirection());
+        r.setContent(m.getContent());
+        r.setStatus(m.getStatus());
+        r.setInstanceId(m.getInstanceId());
+        r.setCreatedAt(m.getCreatedAt());
+        r.setSentByUserId(m.getSentByUserId());
+
+        // Enrich instance display name
+        instanceRepo.findById(m.getInstanceId()).ifPresent(inst ->
+            r.setInstanceDisplayName(inst.getDisplayName()));
+
+        // Enrich sender name
+        if (m.getSentByUserId() != null) {
+            userRepo.findById(m.getSentByUserId()).ifPresent(u ->
+                r.setSentByUserName(u.getFirstName() + " " + u.getLastName()));
+        }
+        return r;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,6 +27,11 @@ spring:
           auth: true
           starttls:
             enable: true
+  rabbitmq:
+    host: ${RABBITMQ_HOST:localhost}
+    port: ${RABBITMQ_PORT:5672}
+    username: ${RABBITMQ_USER:guest}
+    password: ${RABBITMQ_PASSWORD:guest}
 
 springdoc:
   swagger-ui:
@@ -62,3 +67,8 @@ seaweedfs:
     url: ${SEAWEEDFS_MASTER_URL:http://localhost:9333}
   volume:
     public-url: ${SEAWEEDFS_VOLUME_PUBLIC_URL:http://localhost:8080}
+
+evolution:
+  api:
+    url: ${EVOLUTION_API_URL:http://localhost:8081}
+    key: ${EVOLUTION_API_KEY:changeme-evolution-apikey}

--- a/src/main/resources/db/migration/V11__whatsapp.sql
+++ b/src/main/resources/db/migration/V11__whatsapp.sql
@@ -1,0 +1,27 @@
+CREATE TABLE whatsapp_instances (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id UUID NOT NULL REFERENCES tenants(id),
+    instance_name VARCHAR(100) NOT NULL UNIQUE,
+    display_name VARCHAR(100) NOT NULL,
+    phone_number VARCHAR(30),
+    status VARCHAR(20) NOT NULL DEFAULT 'DISCONNECTED',
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE whatsapp_messages (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id UUID NOT NULL REFERENCES tenants(id),
+    lead_id UUID REFERENCES leads(id) ON DELETE SET NULL,
+    instance_id UUID NOT NULL REFERENCES whatsapp_instances(id) ON DELETE CASCADE,
+    direction VARCHAR(10) NOT NULL,
+    content TEXT NOT NULL,
+    sent_by_user_id UUID REFERENCES users(id) ON DELETE SET NULL,
+    external_message_id VARCHAR(255),
+    status VARCHAR(20) NOT NULL DEFAULT 'SENT',
+    created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_wa_messages_lead ON whatsapp_messages(lead_id);
+CREATE INDEX idx_wa_messages_tenant ON whatsapp_messages(tenant_id, created_at DESC);
+CREATE INDEX idx_wa_instances_tenant ON whatsapp_instances(tenant_id);


### PR DESCRIPTION
## Phase 4.5 — WhatsApp Backend

### Changes
- V11 migration: whatsapp_instances + whatsapp_messages tables
- JPA entities, repositories, DTOs
- EvolutionApiClient (HTTP wrapper)
- WhatsappInstanceService + WhatsappMessageService
- RabbitMQ config + consumer (MESSAGES_UPSERT, CONNECTION_UPDATE)
- WhatsappInstanceController + WhatsappMessageController
- application.yml: rabbitmq + evolution.api config (port 8081)