### PR TITLE
feat: WebSocket STOMP for real-time WhatsApp messages and notifications

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -206,6 +206,11 @@
             <artifactId>bcpkix-jdk18on</artifactId>
             <version>1.78.1</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-websocket</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/rinoimob/config/WebSocketAuthInterceptor.java
+++ b/src/main/java/com/rinoimob/config/WebSocketAuthInterceptor.java
@@ -1,0 +1,58 @@
+package com.rinoimob.config;
+
+import com.rinoimob.config.security.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessageDeliveryException;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.UUID;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WebSocketAuthInterceptor implements ChannelInterceptor {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+
+        if (accessor == null || !StompCommand.CONNECT.equals(accessor.getCommand())) {
+            return message;
+        }
+
+        String authHeader = accessor.getFirstNativeHeader("Authorization");
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            log.warn("[WS] CONNECT rejected: missing Authorization header");
+            throw new MessageDeliveryException("Missing Authorization header");
+        }
+
+        String token = authHeader.substring(7);
+        if (!jwtTokenProvider.isTokenValid(token) || !jwtTokenProvider.isAccessToken(token)) {
+            log.warn("[WS] CONNECT rejected: invalid or non-access token");
+            throw new MessageDeliveryException("Invalid token");
+        }
+
+        UUID userId = jwtTokenProvider.getUserIdFromToken(token);
+        String email = jwtTokenProvider.getEmailFromToken(token);
+        String role = jwtTokenProvider.getRoleFromToken(token);
+
+        UsernamePasswordAuthenticationToken auth =
+            new UsernamePasswordAuthenticationToken(email, null, List.of(() -> role));
+        auth.setDetails(userId);
+        accessor.setUser(auth);
+
+        log.debug("[WS] CONNECT accepted for user {}", email);
+        return message;
+    }
+}

--- a/src/main/java/com/rinoimob/config/WebSocketConfig.java
+++ b/src/main/java/com/rinoimob/config/WebSocketConfig.java
@@ -1,0 +1,35 @@
+package com.rinoimob.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.*;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    private final WebSocketAuthInterceptor webSocketAuthInterceptor;
+
+    public WebSocketConfig(WebSocketAuthInterceptor webSocketAuthInterceptor) {
+        this.webSocketAuthInterceptor = webSocketAuthInterceptor;
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker("/topic");
+        registry.setApplicationDestinationPrefixes("/app");
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws")
+            .setAllowedOriginPatterns("*")
+            .withSockJS();
+    }
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(webSocketAuthInterceptor);
+    }
+}

--- a/src/main/java/com/rinoimob/config/WhatsappRabbitMQConfig.java
+++ b/src/main/java/com/rinoimob/config/WhatsappRabbitMQConfig.java
@@ -1,38 +1,19 @@
 package com.rinoimob.config;
 
-import org.springframework.amqp.core.*;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.amqp.support.converter.MessageConverter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class WhatsappRabbitMQConfig {
 
-    public static final String EVOLUTION_EXCHANGE = "evolution";
-    public static final String MESSAGES_QUEUE = "rinoimob.evolution.messages";
-    public static final String CONNECTION_QUEUE = "rinoimob.evolution.connection";
+    // Queues created and managed by Evolution API — we just listen, don't declare
+    public static final String MESSAGES_QUEUE = "evolution.messages.upsert";
+    public static final String CONNECTION_QUEUE = "evolution.connection.update";
 
     @Bean
-    public TopicExchange evolutionExchange() {
-        return ExchangeBuilder.topicExchange(EVOLUTION_EXCHANGE).durable(true).build();
-    }
-
-    @Bean
-    public Queue messagesQueue() {
-        return QueueBuilder.durable(MESSAGES_QUEUE).build();
-    }
-
-    @Bean
-    public Queue connectionQueue() {
-        return QueueBuilder.durable(CONNECTION_QUEUE).build();
-    }
-
-    @Bean
-    public Binding messagesBinding(Queue messagesQueue, TopicExchange evolutionExchange) {
-        return BindingBuilder.bind(messagesQueue).to(evolutionExchange).with("*.MESSAGES_UPSERT");
-    }
-
-    @Bean
-    public Binding connectionBinding(Queue connectionQueue, TopicExchange evolutionExchange) {
-        return BindingBuilder.bind(connectionQueue).to(evolutionExchange).with("*.CONNECTION_UPDATE");
+    public MessageConverter jacksonMessageConverter() {
+        return new Jackson2JsonMessageConverter();
     }
 }

--- a/src/main/java/com/rinoimob/config/security/SecurityConfig.java
+++ b/src/main/java/com/rinoimob/config/security/SecurityConfig.java
@@ -45,6 +45,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.POST, "/api/v1/auth/reset-password").permitAll()
                         .requestMatchers("/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         .requestMatchers("/api/v1/public/**").permitAll()
+                        .requestMatchers("/ws/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/rinoimob/domain/dto/WsMessageEvent.java
+++ b/src/main/java/com/rinoimob/domain/dto/WsMessageEvent.java
@@ -1,0 +1,11 @@
+package com.rinoimob.domain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class WsMessageEvent {
+    private String type;        // "WHATSAPP_MESSAGE" | "NOTIFICATION"
+    private Object payload;
+}

--- a/src/main/java/com/rinoimob/messaging/consumer/WhatsappRabbitMqConsumer.java
+++ b/src/main/java/com/rinoimob/messaging/consumer/WhatsappRabbitMqConsumer.java
@@ -1,56 +1,74 @@
 package com.rinoimob.messaging.consumer;
 
 import com.rinoimob.config.WhatsappRabbitMQConfig;
+import com.rinoimob.domain.dto.WhatsappMessageResponse;
+import com.rinoimob.domain.dto.WsMessageEvent;
 import com.rinoimob.domain.entity.WhatsappMessage;
 import com.rinoimob.domain.repository.LeadRepository;
 import com.rinoimob.domain.repository.WhatsappInstanceRepository;
 import com.rinoimob.domain.repository.WhatsappMessageRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.logging.Logger;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class WhatsappRabbitMqConsumer {
 
-    private static final Logger log = Logger.getLogger(WhatsappRabbitMqConsumer.class.getName());
-
     private final WhatsappInstanceRepository instanceRepo;
     private final WhatsappMessageRepository messageRepo;
     private final LeadRepository leadRepo;
+    private final SimpMessagingTemplate messagingTemplate;
 
     @RabbitListener(queues = WhatsappRabbitMQConfig.MESSAGES_QUEUE)
     @SuppressWarnings("unchecked")
-    public void handleMessageUpsert(Map<String, Object> payload) {
+    public void handleEvent(Map<String, Object> payload) {
         try {
             String instanceName = (String) payload.get("instance");
             if (instanceName == null) return;
 
-            instanceRepo.findByInstanceName(instanceName).ifPresent(instance -> {
-                Object dataObj = payload.get("data");
-                if (!(dataObj instanceof Map)) return;
-                Map<String, Object> data = (Map<String, Object>) dataObj;
+            log.debug("Received Evolution event '{}' for instance '{}'", payload.get("event"), instanceName);
+            handleMessageUpsert(instanceName, payload);
+        } catch (Exception e) {
+            log.warn("Error processing Evolution event: {}", e.getMessage());
+        }
+    }
 
+    @SuppressWarnings("unchecked")
+    private void handleMessageUpsert(String instanceName, Map<String, Object> payload) {
+        instanceRepo.findByInstanceName(instanceName).ifPresent(instance -> {
+            Object dataObj = payload.get("data");
+            List<Map<String, Object>> messages;
+            if (dataObj instanceof List) {
+                messages = (List<Map<String, Object>>) dataObj;
+            } else if (dataObj instanceof Map) {
+                messages = List.of((Map<String, Object>) dataObj);
+            } else {
+                log.warn("Unexpected data type in MESSAGES_UPSERT: {}", dataObj != null ? dataObj.getClass() : "null");
+                return;
+            }
+
+            for (Map<String, Object> data : messages) {
                 Object keyObj = data.get("key");
-                if (!(keyObj instanceof Map)) return;
+                if (!(keyObj instanceof Map)) continue;
                 Map<String, Object> key = (Map<String, Object>) keyObj;
 
-                // Skip messages sent by us
-                if (Boolean.TRUE.equals(key.get("fromMe"))) return;
+                if (Boolean.TRUE.equals(key.get("fromMe"))) continue;
 
                 String remoteJid = (String) key.get("remoteJid");
-                if (remoteJid == null || remoteJid.contains("@g.us")) return; // skip groups
+                if (remoteJid == null || remoteJid.contains("@g.us")) continue;
 
                 String fromNumber = remoteJid.replace("@s.whatsapp.net", "").replaceAll("\\D", "");
-
                 String text = extractText(data);
-                if (text == null || text.isBlank()) return;
+                if (text == null || text.isBlank()) continue;
 
-                // Match lead by phone within the tenant
                 UUID leadId = leadRepo.findByTenantIdAndDeletedAtIsNull(instance.getTenantId()).stream()
                     .filter(l -> l.getPhone() != null && (
                         l.getPhone().replaceAll("\\D", "").endsWith(fromNumber) ||
@@ -58,6 +76,11 @@ public class WhatsappRabbitMqConsumer {
                     .findFirst()
                     .map(l -> l.getId())
                     .orElse(null);
+
+                // Resolve lead name for notification display
+                String leadName = leadId != null
+                    ? leadRepo.findById(leadId).map(l -> l.getName()).orElse(null)
+                    : null;
 
                 WhatsappMessage msg = new WhatsappMessage();
                 msg.setTenantId(instance.getTenantId());
@@ -67,36 +90,62 @@ public class WhatsappRabbitMqConsumer {
                 msg.setContent(text);
                 msg.setStatus("RECEIVED");
                 messageRepo.save(msg);
-            });
-        } catch (Exception e) {
-            log.warning("Error processing WhatsApp message: " + e.getMessage());
-        }
+
+                // Push to WebSocket subscribers — enrich with fromNumber and leadName
+                Map<String, Object> wsPayload = Map.of(
+                    "id", msg.getId().toString(),
+                    "direction", "INBOUND",
+                    "content", text,
+                    "status", "RECEIVED",
+                    "instanceId", msg.getInstanceId().toString(),
+                    "leadId", leadId != null ? leadId.toString() : "",
+                    "fromNumber", fromNumber,
+                    "senderName", leadName != null ? leadName : ("+" + fromNumber),
+                    "createdAt", msg.getCreatedAt().toString()
+                );
+                WsMessageEvent event = new WsMessageEvent("WHATSAPP_MESSAGE", wsPayload);
+
+                if (msg.getLeadId() != null) {
+                    messagingTemplate.convertAndSend(
+                        "/topic/" + instance.getTenantId() + ".whatsapp.lead." + msg.getLeadId(), event);
+                }
+                messagingTemplate.convertAndSend(
+                    "/topic/" + instance.getTenantId() + ".whatsapp", event);
+
+                log.info("Saved INBOUND message from {} for instance {}", fromNumber, instanceName);
+            }
+        });
     }
 
     @RabbitListener(queues = WhatsappRabbitMQConfig.CONNECTION_QUEUE)
     @SuppressWarnings("unchecked")
-    public void handleConnectionUpdate(Map<String, Object> payload) {
+    public void handleConnectionEvent(Map<String, Object> payload) {
         try {
             String instanceName = (String) payload.get("instance");
             if (instanceName == null) return;
-
-            Object dataObj = payload.get("data");
-            if (!(dataObj instanceof Map)) return;
-            Map<String, Object> data = (Map<String, Object>) dataObj;
-            String state = (String) data.get("state"); // open | close | connecting
-
-            instanceRepo.findByInstanceName(instanceName).ifPresent(instance -> {
-                String newStatus = switch (state != null ? state : "") {
-                    case "open" -> "CONNECTED";
-                    case "connecting" -> "CONNECTING";
-                    default -> "DISCONNECTED";
-                };
-                instance.setStatus(newStatus);
-                instanceRepo.save(instance);
-            });
+            handleConnectionUpdate(instanceName, payload);
         } catch (Exception e) {
-            log.warning("Error processing connection update: " + e.getMessage());
+            log.warn("Error processing connection update: {}", e.getMessage());
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void handleConnectionUpdate(String instanceName, Map<String, Object> payload) {
+        Object dataObj = payload.get("data");
+        if (!(dataObj instanceof Map)) return;
+        Map<String, Object> data = (Map<String, Object>) dataObj;
+        String state = (String) data.get("state");
+
+        instanceRepo.findByInstanceName(instanceName).ifPresent(instance -> {
+            String newStatus = switch (state != null ? state : "") {
+                case "open" -> "CONNECTED";
+                case "connecting" -> "CONNECTING";
+                default -> "DISCONNECTED";
+            };
+            instance.setStatus(newStatus);
+            instanceRepo.save(instance);
+            log.info("Instance {} status updated to {}", instanceName, newStatus);
+        });
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/com/rinoimob/service/WhatsappInstanceService.java
+++ b/src/main/java/com/rinoimob/service/WhatsappInstanceService.java
@@ -28,8 +28,27 @@ public class WhatsappInstanceService {
 
     public List<WhatsappInstanceResponse> listForTenant() {
         UUID tenantId = UUID.fromString(TenantContext.getTenantId());
-        return instanceRepo.findByTenantIdOrderByCreatedAtAsc(tenantId)
-            .stream().map(this::toResponse).toList();
+        List<WhatsappInstance> instances = instanceRepo.findByTenantIdOrderByCreatedAtAsc(tenantId);
+
+        // Sync connection status from Evolution API on every listing
+        instances.forEach(instance -> {
+            try {
+                String state = evolutionClient.getConnectionState(instance.getInstanceName());
+                String newStatus = switch (state) {
+                    case "open" -> "CONNECTED";
+                    case "connecting" -> "CONNECTING";
+                    default -> "DISCONNECTED";
+                };
+                if (!newStatus.equals(instance.getStatus())) {
+                    instance.setStatus(newStatus);
+                    instanceRepo.save(instance);
+                }
+            } catch (Exception e) {
+                log.warn("Could not sync status for instance '{}': {}", instance.getInstanceName(), e.getMessage());
+            }
+        });
+
+        return instances.stream().map(this::toResponse).toList();
     }
 
     public WhatsappInstanceResponse create(CreateWhatsappInstanceRequest req) {


### PR DESCRIPTION
## O que muda

- **WebSocket STOMP** endpoint `/ws` com SockJS
- **Autenticação JWT** no frame CONNECT via `WebSocketAuthInterceptor`
- **WhatsappRabbitMqConsumer** corrigido: desserialização `byte[]` → Map via Jackson, payload `data` como List, eventos WS enriquecidos com `fromNumber`/`senderName`/`leadId`
- **WhatsappInstanceService**: sincroniza status do Evolution API a cada listagem
- **SecurityConfig**: libera `/ws/**` para handshake HTTP (auth real é no STOMP)
- Dependência `spring-boot-starter-websocket` adicionada