### PR TITLE
feat: Phase 5 - Custom Roles, Permissions & Redis Token Whitelist

### DIFF
--- a/src/main/java/com/rinoimob/api/controller/AuthController.java
+++ b/src/main/java/com/rinoimob/api/controller/AuthController.java
@@ -93,6 +93,17 @@ public class AuthController {
         return ResponseEntity.ok(response);
     }
 
+    @PostMapping("/logout")
+    @Operation(summary = "Logout and revoke current token")
+    public ResponseEntity<Void> logout(HttpServletRequest request) {
+        UUID userId = (UUID) request.getAttribute("userId");
+        String jti = (String) request.getAttribute("jti");
+        if (userId != null) {
+            authService.logout(userId, jti);
+        }
+        return ResponseEntity.ok().build();
+    }
+
     @PostMapping("/verify-email")
     @Operation(summary = "Verify email with token")
     public ResponseEntity<Void> verifyEmail(@RequestParam String token) {
@@ -118,4 +129,3 @@ public class AuthController {
         return new ResponseStatusException(HttpStatus.BAD_REQUEST, "Tenant context not found");
     }
 }
-

--- a/src/main/java/com/rinoimob/api/controller/CategoryController.java
+++ b/src/main/java/com/rinoimob/api/controller/CategoryController.java
@@ -10,6 +10,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -25,18 +26,21 @@ public class CategoryController {
 
     @GetMapping
     @Operation(summary = "List all categories available to the current tenant (globals + own)")
+    @PreAuthorize("hasAuthority('PERMISSION_categories:read')")
     public ResponseEntity<List<CategoryResponse>> list() {
         return ResponseEntity.ok(categoryService.listAvailable());
     }
 
     @PostMapping
     @Operation(summary = "Create a new category for the current tenant")
+    @PreAuthorize("hasAuthority('PERMISSION_categories:write')")
     public ResponseEntity<CategoryResponse> create(@Valid @RequestBody CreateCategoryRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED).body(categoryService.create(request));
     }
 
     @PutMapping("/{id}")
     @Operation(summary = "Update an existing tenant-owned category")
+    @PreAuthorize("hasAuthority('PERMISSION_categories:write')")
     public ResponseEntity<CategoryResponse> update(
             @PathVariable UUID id,
             @Valid @RequestBody UpdateCategoryRequest request) {
@@ -45,6 +49,7 @@ public class CategoryController {
 
     @DeleteMapping("/{id}")
     @Operation(summary = "Delete a tenant-owned category")
+    @PreAuthorize("hasAuthority('PERMISSION_categories:write')")
     public ResponseEntity<Void> delete(@PathVariable UUID id) {
         categoryService.delete(id);
         return ResponseEntity.noContent().build();

--- a/src/main/java/com/rinoimob/api/controller/LeadController.java
+++ b/src/main/java/com/rinoimob/api/controller/LeadController.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -23,12 +24,14 @@ public class LeadController {
     private final LeadService leadService;
 
     @GetMapping("/stats")
+    @PreAuthorize("hasAuthority('PERMISSION_leads:read')")
     public LeadStatsResponse stats() {
         UUID tenantId = UUID.fromString(TenantContext.getTenantId());
         return leadService.getStats(tenantId);
     }
 
     @GetMapping
+    @PreAuthorize("hasAuthority('PERMISSION_leads:read')")
     public ResponseEntity<Page<LeadResponse>> list(
             @RequestParam(required = false) LeadStatus status,
             @RequestParam(defaultValue = "0") int page,
@@ -38,12 +41,14 @@ public class LeadController {
     }
 
     @GetMapping("/{id}")
+    @PreAuthorize("hasAuthority('PERMISSION_leads:read')")
     public ResponseEntity<LeadResponse> get(@PathVariable UUID id) {
         UUID tenantId = UUID.fromString(TenantContext.getTenantId());
         return ResponseEntity.ok(leadService.get(tenantId, id));
     }
 
     @PostMapping
+    @PreAuthorize("hasAuthority('PERMISSION_leads:write')")
     public ResponseEntity<LeadResponse> create(
             @Valid @RequestBody CreateLeadRequest request) {
         UUID tenantId = UUID.fromString(TenantContext.getTenantId());
@@ -51,6 +56,7 @@ public class LeadController {
     }
 
     @PutMapping("/{id}")
+    @PreAuthorize("hasAuthority('PERMISSION_leads:write')")
     public ResponseEntity<LeadResponse> update(
             @PathVariable UUID id,
             @RequestBody UpdateLeadRequest request) {
@@ -59,6 +65,7 @@ public class LeadController {
     }
 
     @DeleteMapping("/{id}")
+    @PreAuthorize("hasAuthority('PERMISSION_leads:write')")
     public ResponseEntity<Void> delete(@PathVariable UUID id) {
         UUID tenantId = UUID.fromString(TenantContext.getTenantId());
         leadService.delete(tenantId, id);
@@ -66,6 +73,7 @@ public class LeadController {
     }
 
     @PostMapping("/{id}/notes")
+    @PreAuthorize("hasAuthority('PERMISSION_leads:write')")
     public ResponseEntity<LeadNoteResponse> addNote(
             @PathVariable UUID id,
             @Valid @RequestBody LeadNoteRequest request,
@@ -76,18 +84,21 @@ public class LeadController {
     }
 
     @GetMapping("/{id}/events")
+    @PreAuthorize("hasAuthority('PERMISSION_leads:read')")
     public ResponseEntity<List<LeadEventResponse>> getEvents(@PathVariable UUID id) {
         UUID tenantId = UUID.fromString(TenantContext.getTenantId());
         return ResponseEntity.ok(leadService.getEvents(tenantId, id));
     }
 
     @GetMapping("/{id}/properties")
+    @PreAuthorize("hasAuthority('PERMISSION_leads:read')")
     public ResponseEntity<List<LeadPropertyResponse>> getProperties(@PathVariable UUID id) {
         UUID tenantId = UUID.fromString(TenantContext.getTenantId());
         return ResponseEntity.ok(leadService.getProperties(tenantId, id));
     }
 
     @PostMapping("/{id}/properties")
+    @PreAuthorize("hasAuthority('PERMISSION_leads:write')")
     public ResponseEntity<LeadPropertyResponse> addProperty(
             @PathVariable UUID id,
             @Valid @RequestBody AddLeadPropertyRequest request) {
@@ -96,6 +107,7 @@ public class LeadController {
     }
 
     @PatchMapping("/{id}/properties/{linkId}")
+    @PreAuthorize("hasAuthority('PERMISSION_leads:write')")
     public ResponseEntity<LeadPropertyResponse> updatePropertyInterest(
             @PathVariable UUID id,
             @PathVariable UUID linkId,
@@ -105,6 +117,7 @@ public class LeadController {
     }
 
     @DeleteMapping("/{id}/properties/{linkId}")
+    @PreAuthorize("hasAuthority('PERMISSION_leads:write')")
     public ResponseEntity<Void> removeProperty(
             @PathVariable UUID id,
             @PathVariable UUID linkId) {

--- a/src/main/java/com/rinoimob/api/controller/PropertyController.java
+++ b/src/main/java/com/rinoimob/api/controller/PropertyController.java
@@ -13,6 +13,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -27,6 +28,7 @@ public class PropertyController {
     private final PropertyService propertyService;
 
     @GetMapping
+    @PreAuthorize("hasAuthority('PERMISSION_properties:read')")
     public ResponseEntity<Page<PropertySummaryResponse>> list(
             @RequestParam(required = false) PropertyStatus status,
             @RequestParam(required = false) PropertyOperation operation,
@@ -41,16 +43,19 @@ public class PropertyController {
     }
 
     @PostMapping
+    @PreAuthorize("hasAuthority('PERMISSION_properties:write')")
     public ResponseEntity<PropertyResponse> create(@Valid @RequestBody CreatePropertyRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED).body(propertyService.createProperty(request));
     }
 
     @GetMapping("/{id}")
+    @PreAuthorize("hasAuthority('PERMISSION_properties:read')")
     public ResponseEntity<PropertyResponse> get(@PathVariable UUID id) {
         return ResponseEntity.ok(propertyService.getProperty(id));
     }
 
     @PutMapping("/{id}")
+    @PreAuthorize("hasAuthority('PERMISSION_properties:write')")
     public ResponseEntity<PropertyResponse> update(
             @PathVariable UUID id,
             @RequestBody UpdatePropertyRequest request) {
@@ -58,6 +63,7 @@ public class PropertyController {
     }
 
     @DeleteMapping("/{id}")
+    @PreAuthorize("hasAuthority('PERMISSION_properties:write')")
     public ResponseEntity<Void> delete(@PathVariable UUID id) {
         propertyService.deleteProperty(id);
         return ResponseEntity.noContent().build();
@@ -66,6 +72,7 @@ public class PropertyController {
     // ── Photos ────────────────────────────────────────────────────────────────
 
     @PostMapping(value = "/{id}/photos", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PreAuthorize("hasAuthority('PERMISSION_properties:write')")
     public ResponseEntity<PropertyPhotoResponse> uploadPhoto(
             @PathVariable UUID id,
             @RequestPart("file") MultipartFile file,
@@ -74,12 +81,14 @@ public class PropertyController {
     }
 
     @PatchMapping("/{id}/photos/{photoId}/cover")
+    @PreAuthorize("hasAuthority('PERMISSION_properties:write')")
     public ResponseEntity<Void> setCover(@PathVariable UUID id, @PathVariable UUID photoId) {
         propertyService.setCoverPhoto(id, photoId);
         return ResponseEntity.noContent().build();
     }
 
     @DeleteMapping("/{id}/photos/{photoId}")
+    @PreAuthorize("hasAuthority('PERMISSION_properties:write')")
     public ResponseEntity<Void> deletePhoto(@PathVariable UUID id, @PathVariable UUID photoId) {
         propertyService.deletePhoto(id, photoId);
         return ResponseEntity.noContent().build();
@@ -88,6 +97,7 @@ public class PropertyController {
     // ── Floor Plans ───────────────────────────────────────────────────────────
 
     @PostMapping("/{id}/floor-plans")
+    @PreAuthorize("hasAuthority('PERMISSION_properties:write')")
     public ResponseEntity<FloorPlanResponse> addFloorPlan(
             @PathVariable UUID id,
             @Valid @RequestBody CreateFloorPlanRequest request) {
@@ -95,12 +105,14 @@ public class PropertyController {
     }
 
     @DeleteMapping("/{id}/floor-plans/{planId}")
+    @PreAuthorize("hasAuthority('PERMISSION_properties:write')")
     public ResponseEntity<Void> deleteFloorPlan(@PathVariable UUID id, @PathVariable UUID planId) {
         propertyService.deleteFloorPlan(id, planId);
         return ResponseEntity.noContent().build();
     }
 
     @PostMapping(value = "/{id}/floor-plans/{planId}/photos", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PreAuthorize("hasAuthority('PERMISSION_properties:write')")
     public ResponseEntity<FloorPlanPhotoResponse> uploadFloorPlanPhoto(
             @PathVariable UUID id,
             @PathVariable UUID planId,

--- a/src/main/java/com/rinoimob/api/controller/TaskController.java
+++ b/src/main/java/com/rinoimob/api/controller/TaskController.java
@@ -9,6 +9,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
@@ -21,6 +22,7 @@ public class TaskController {
     private final TaskService taskService;
 
     @GetMapping
+    @PreAuthorize("hasAuthority('PERMISSION_tasks:read')")
     public Page<TaskResponse> list(
             @RequestParam(required = false) Boolean pending,
             @RequestParam(required = false) UUID leadId,
@@ -33,18 +35,21 @@ public class TaskController {
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
+    @PreAuthorize("hasAuthority('PERMISSION_tasks:write')")
     public TaskResponse create(@Valid @RequestBody CreateTaskRequest req) {
         UUID tenantId = UUID.fromString(TenantContext.getTenantId());
         return taskService.create(tenantId, req);
     }
 
     @PutMapping("/{id}")
+    @PreAuthorize("hasAuthority('PERMISSION_tasks:write')")
     public TaskResponse update(@PathVariable UUID id, @RequestBody UpdateTaskRequest req) {
         UUID tenantId = UUID.fromString(TenantContext.getTenantId());
         return taskService.update(id, tenantId, req);
     }
 
     @PostMapping("/{id}/complete")
+    @PreAuthorize("hasAuthority('PERMISSION_tasks:write')")
     public TaskResponse complete(@PathVariable UUID id) {
         UUID tenantId = UUID.fromString(TenantContext.getTenantId());
         return taskService.complete(id, tenantId);
@@ -52,6 +57,7 @@ public class TaskController {
 
     @DeleteMapping("/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
+    @PreAuthorize("hasAuthority('PERMISSION_tasks:write')")
     public void delete(@PathVariable UUID id) {
         UUID tenantId = UUID.fromString(TenantContext.getTenantId());
         taskService.delete(id, tenantId);

--- a/src/main/java/com/rinoimob/api/controller/TaskTypeController.java
+++ b/src/main/java/com/rinoimob/api/controller/TaskTypeController.java
@@ -8,6 +8,7 @@ import com.rinoimob.service.TaskTypeService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -21,6 +22,7 @@ public class TaskTypeController {
     private final TaskTypeService taskTypeService;
 
     @GetMapping
+    @PreAuthorize("hasAuthority('PERMISSION_task_types:read')")
     public List<TaskTypeResponse> list() {
         UUID tenantId = UUID.fromString(TenantContext.getTenantId());
         return taskTypeService.list(tenantId);
@@ -28,12 +30,14 @@ public class TaskTypeController {
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
+    @PreAuthorize("hasAuthority('PERMISSION_task_types:write')")
     public TaskTypeResponse create(@Valid @RequestBody CreateTaskTypeRequest req) {
         UUID tenantId = UUID.fromString(TenantContext.getTenantId());
         return taskTypeService.create(tenantId, req);
     }
 
     @PutMapping("/{id}")
+    @PreAuthorize("hasAuthority('PERMISSION_task_types:write')")
     public TaskTypeResponse update(@PathVariable UUID id, @RequestBody UpdateTaskTypeRequest req) {
         UUID tenantId = UUID.fromString(TenantContext.getTenantId());
         return taskTypeService.update(id, tenantId, req);
@@ -41,6 +45,7 @@ public class TaskTypeController {
 
     @DeleteMapping("/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
+    @PreAuthorize("hasAuthority('PERMISSION_task_types:write')")
     public void delete(@PathVariable UUID id) {
         UUID tenantId = UUID.fromString(TenantContext.getTenantId());
         taskTypeService.delete(id, tenantId);

--- a/src/main/java/com/rinoimob/api/controller/TenantRoleController.java
+++ b/src/main/java/com/rinoimob/api/controller/TenantRoleController.java
@@ -1,0 +1,59 @@
+package com.rinoimob.api.controller;
+
+import com.rinoimob.context.TenantContext;
+import com.rinoimob.domain.dto.CreateTenantRoleRequest;
+import com.rinoimob.domain.dto.TenantRoleResponse;
+import com.rinoimob.domain.dto.UpdateTenantRoleRequest;
+import com.rinoimob.service.TenantRoleService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/roles")
+@RequiredArgsConstructor
+public class TenantRoleController {
+
+    private final TenantRoleService tenantRoleService;
+
+    @GetMapping
+    @PreAuthorize("hasAuthority('PERMISSION_roles:read') or hasAuthority('PERMISSION_roles:write')")
+    public ResponseEntity<List<TenantRoleResponse>> listRoles() {
+        UUID tenantId = UUID.fromString(TenantContext.getTenantId());
+        return ResponseEntity.ok(tenantRoleService.listRoles(tenantId));
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("hasAuthority('PERMISSION_roles:read') or hasAuthority('PERMISSION_roles:write')")
+    public ResponseEntity<TenantRoleResponse> getRole(@PathVariable UUID id) {
+        UUID tenantId = UUID.fromString(TenantContext.getTenantId());
+        return ResponseEntity.ok(tenantRoleService.getRole(tenantId, id));
+    }
+
+    @PostMapping
+    @PreAuthorize("hasAuthority('PERMISSION_roles:write')")
+    public ResponseEntity<TenantRoleResponse> createRole(@RequestBody CreateTenantRoleRequest request) {
+        UUID tenantId = UUID.fromString(TenantContext.getTenantId());
+        return ResponseEntity.status(HttpStatus.CREATED).body(tenantRoleService.createRole(tenantId, request));
+    }
+
+    @PutMapping("/{id}")
+    @PreAuthorize("hasAuthority('PERMISSION_roles:write')")
+    public ResponseEntity<TenantRoleResponse> updateRole(@PathVariable UUID id, @RequestBody UpdateTenantRoleRequest request) {
+        UUID tenantId = UUID.fromString(TenantContext.getTenantId());
+        return ResponseEntity.ok(tenantRoleService.updateRole(tenantId, id, request));
+    }
+
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasAuthority('PERMISSION_roles:write')")
+    public ResponseEntity<Void> deleteRole(@PathVariable UUID id) {
+        UUID tenantId = UUID.fromString(TenantContext.getTenantId());
+        tenantRoleService.deleteRole(tenantId, id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/rinoimob/api/controller/UserManagementController.java
+++ b/src/main/java/com/rinoimob/api/controller/UserManagementController.java
@@ -1,0 +1,54 @@
+package com.rinoimob.api.controller;
+
+import com.rinoimob.context.TenantContext;
+import com.rinoimob.domain.dto.InviteUserRequest;
+import com.rinoimob.domain.dto.UpdateUserRoleRequest;
+import com.rinoimob.domain.dto.UserManagementResponse;
+import com.rinoimob.service.UserManagementService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/team/users")
+@RequiredArgsConstructor
+public class UserManagementController {
+
+    private final UserManagementService userManagementService;
+
+    @GetMapping
+    @PreAuthorize("hasAuthority('PERMISSION_users:read')")
+    public ResponseEntity<List<UserManagementResponse>> listUsers() {
+        UUID tenantId = UUID.fromString(TenantContext.getTenantId());
+        return ResponseEntity.ok(userManagementService.listUsers(tenantId));
+    }
+
+    @PostMapping("/invite")
+    @PreAuthorize("hasAuthority('PERMISSION_users:write')")
+    public ResponseEntity<UserManagementResponse> inviteUser(@RequestBody InviteUserRequest request) {
+        UUID tenantId = UUID.fromString(TenantContext.getTenantId());
+        return ResponseEntity.status(HttpStatus.CREATED).body(userManagementService.inviteUser(tenantId, request));
+    }
+
+    @PutMapping("/{id}/role")
+    @PreAuthorize("hasAuthority('PERMISSION_users:write')")
+    public ResponseEntity<UserManagementResponse> assignRole(
+            @PathVariable UUID id,
+            @RequestBody UpdateUserRoleRequest request) {
+        UUID tenantId = UUID.fromString(TenantContext.getTenantId());
+        return ResponseEntity.ok(userManagementService.assignRole(tenantId, id, request.roleId()));
+    }
+
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasAuthority('PERMISSION_users:write')")
+    public ResponseEntity<Void> deactivateUser(@PathVariable UUID id) {
+        UUID tenantId = UUID.fromString(TenantContext.getTenantId());
+        userManagementService.deactivateUser(tenantId, id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/rinoimob/api/controller/WhatsappInstanceController.java
+++ b/src/main/java/com/rinoimob/api/controller/WhatsappInstanceController.java
@@ -6,6 +6,7 @@ import com.rinoimob.domain.dto.WhatsappQrCodeResponse;
 import com.rinoimob.service.WhatsappInstanceService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -19,26 +20,31 @@ public class WhatsappInstanceController {
     private final WhatsappInstanceService service;
 
     @GetMapping
+    @PreAuthorize("hasAuthority('PERMISSION_whatsapp:read')")
     public ResponseEntity<List<WhatsappInstanceResponse>> list() {
         return ResponseEntity.ok(service.listForTenant());
     }
 
     @PostMapping
+    @PreAuthorize("hasAuthority('PERMISSION_whatsapp:write')")
     public ResponseEntity<WhatsappInstanceResponse> create(@RequestBody CreateWhatsappInstanceRequest req) {
         return ResponseEntity.status(201).body(service.create(req));
     }
 
     @GetMapping("/{id}/qrcode")
+    @PreAuthorize("hasAuthority('PERMISSION_whatsapp:read')")
     public ResponseEntity<WhatsappQrCodeResponse> qrCode(@PathVariable UUID id) {
         return ResponseEntity.ok(service.getQrCode(id));
     }
 
     @GetMapping("/{id}/status")
+    @PreAuthorize("hasAuthority('PERMISSION_whatsapp:read')")
     public ResponseEntity<WhatsappInstanceResponse> status(@PathVariable UUID id) {
         return ResponseEntity.ok(service.getStatus(id));
     }
 
     @DeleteMapping("/{id}")
+    @PreAuthorize("hasAuthority('PERMISSION_whatsapp:write')")
     public ResponseEntity<Void> delete(@PathVariable UUID id) {
         service.delete(id);
         return ResponseEntity.noContent().build();

--- a/src/main/java/com/rinoimob/api/controller/WhatsappMessageController.java
+++ b/src/main/java/com/rinoimob/api/controller/WhatsappMessageController.java
@@ -6,6 +6,7 @@ import com.rinoimob.service.WhatsappMessageService;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -19,11 +20,13 @@ public class WhatsappMessageController {
     private final WhatsappMessageService service;
 
     @GetMapping("/{leadId}/messages")
+    @PreAuthorize("hasAuthority('PERMISSION_whatsapp:read')")
     public ResponseEntity<List<WhatsappMessageResponse>> getMessages(@PathVariable UUID leadId) {
         return ResponseEntity.ok(service.getMessagesForLead(leadId));
     }
 
     @PostMapping("/{leadId}/messages")
+    @PreAuthorize("hasAuthority('PERMISSION_whatsapp:write')")
     public ResponseEntity<WhatsappMessageResponse> send(
             @PathVariable UUID leadId,
             @RequestBody SendWhatsappMessageRequest req,

--- a/src/main/java/com/rinoimob/config/RedisConfig.java
+++ b/src/main/java/com/rinoimob/config/RedisConfig.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 @EnableCaching
@@ -14,6 +15,19 @@ public class RedisConfig {
     public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
         RedisTemplate<String, Object> template = new RedisTemplate<>();
         template.setConnectionFactory(connectionFactory);
+        template.afterPropertiesSet();
+        return template;
+    }
+
+    @Bean
+    public RedisTemplate<String, String> stringRedisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        StringRedisSerializer serializer = new StringRedisSerializer();
+        template.setKeySerializer(serializer);
+        template.setValueSerializer(serializer);
+        template.setHashKeySerializer(serializer);
+        template.setHashValueSerializer(serializer);
         template.afterPropertiesSet();
         return template;
     }

--- a/src/main/java/com/rinoimob/config/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/rinoimob/config/security/JwtAuthenticationFilter.java
@@ -1,6 +1,7 @@
 package com.rinoimob.config.security;
 
 import com.rinoimob.context.TenantContext;
+import com.rinoimob.service.auth.TokenService;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -14,15 +15,18 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
 @Slf4j
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider tokenProvider;
+    private final TokenService tokenService;
 
-    public JwtAuthenticationFilter(JwtTokenProvider tokenProvider) {
+    public JwtAuthenticationFilter(JwtTokenProvider tokenProvider, TokenService tokenService) {
         this.tokenProvider = tokenProvider;
+        this.tokenService = tokenService;
     }
 
     @Override
@@ -32,14 +36,26 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             String jwt = getJwtFromRequest(request);
 
             if (StringUtils.hasText(jwt) && tokenProvider.isAccessToken(jwt) && tokenProvider.isTokenValid(jwt)) {
+                String jti = tokenProvider.getJtiFromToken(jwt);
+
+                if (jti != null && !tokenService.isValid(jti)) {
+                    filterChain.doFilter(request, response);
+                    return;
+                }
+
                 var userId = tokenProvider.getUserIdFromToken(jwt);
                 var email = tokenProvider.getEmailFromToken(jwt);
                 var role = tokenProvider.getRoleFromToken(jwt);
                 var tenantId = tokenProvider.getTenantIdFromToken(jwt);
+                var permissions = tokenProvider.getPermissionsFromToken(jwt);
 
-                var authorities = (role != null)
-                        ? List.of(new SimpleGrantedAuthority("ROLE_" + role))
-                        : List.<SimpleGrantedAuthority>of();
+                List<SimpleGrantedAuthority> authorities = new ArrayList<>();
+                if (role != null) {
+                    authorities.add(new SimpleGrantedAuthority("ROLE_" + role));
+                }
+                for (String permission : permissions) {
+                    authorities.add(new SimpleGrantedAuthority("PERMISSION_" + permission));
+                }
 
                 UsernamePasswordAuthenticationToken authentication =
                         new UsernamePasswordAuthenticationToken(email, null, authorities);
@@ -49,6 +65,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 request.setAttribute("userId", userId);
                 request.setAttribute("email", email);
                 request.setAttribute("role", role);
+                if (jti != null) {
+                    request.setAttribute("jti", jti);
+                }
 
                 if (tenantId != null) {
                     TenantContext.setTenantId(tenantId.toString());

--- a/src/main/java/com/rinoimob/config/security/JwtTokenProvider.java
+++ b/src/main/java/com/rinoimob/config/security/JwtTokenProvider.java
@@ -31,29 +31,44 @@ public class JwtTokenProvider {
     private long refreshTokenExpiration;
 
     public String generateAccessToken(UUID userId, String email, String role, UUID tenantId) {
-        return generateToken(userId, email, role, tenantId, accessTokenExpiration, "access");
+        return generateAccessToken(userId, email, role, tenantId, List.of());
     }
 
-    public String generateRefreshToken(UUID userId, String email) {
-        return generateToken(userId, email, null, null, refreshTokenExpiration, "refresh");
-    }
-
-    private String generateToken(UUID userId, String email, String role, UUID tenantId, long expiration, String type) {
+    public String generateAccessToken(UUID userId, String email, String role, UUID tenantId, List<String> permissions) {
+        String jti = UUID.randomUUID().toString();
         Map<String, Object> claims = new HashMap<>();
         claims.put("email", email);
-        claims.put("type", type);
+        claims.put("type", "access");
+        claims.put("jti", jti);
         if (role != null) {
             claims.put("role", role);
         }
         if (tenantId != null) {
             claims.put("tenantId", tenantId.toString());
         }
+        if (permissions != null && !permissions.isEmpty()) {
+            claims.put("permissions", String.join(",", permissions));
+        }
 
         return Jwts.builder()
                 .setClaims(claims)
                 .setSubject(userId.toString())
                 .setIssuedAt(new Date())
-                .setExpiration(new Date(System.currentTimeMillis() + expiration))
+                .setExpiration(new Date(System.currentTimeMillis() + accessTokenExpiration))
+                .signWith(getSigningKey(), SignatureAlgorithm.HS512)
+                .compact();
+    }
+
+    public String generateRefreshToken(UUID userId, String email) {
+        Map<String, Object> claims = new HashMap<>();
+        claims.put("email", email);
+        claims.put("type", "refresh");
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setSubject(userId.toString())
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + refreshTokenExpiration))
                 .signWith(getSigningKey(), SignatureAlgorithm.HS512)
                 .compact();
     }
@@ -81,6 +96,33 @@ public class JwtTokenProvider {
         } catch (Exception e) {
             return null;
         }
+    }
+
+    public String getJtiFromToken(String token) {
+        try {
+            Claims claims = getAllClaimsFromToken(token);
+            return claims.get("jti", String.class);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    public List<String> getPermissionsFromToken(String token) {
+        try {
+            Claims claims = getAllClaimsFromToken(token);
+            String perms = claims.get("permissions", String.class);
+            if (perms == null || perms.isBlank()) return List.of();
+            return Arrays.stream(perms.split(","))
+                    .map(String::trim)
+                    .filter(s -> !s.isEmpty())
+                    .collect(Collectors.toList());
+        } catch (Exception e) {
+            return List.of();
+        }
+    }
+
+    public long getAccessTokenTtlSeconds() {
+        return accessTokenExpiration / 1000;
     }
 
     public boolean isTokenValid(String token) {

--- a/src/main/java/com/rinoimob/config/security/SecurityConfig.java
+++ b/src/main/java/com/rinoimob/config/security/SecurityConfig.java
@@ -1,10 +1,12 @@
 package com.rinoimob.config.security;
 
+import com.rinoimob.service.auth.TokenService;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -19,12 +21,15 @@ import java.util.List;
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity(prePostEnabled = true)
 public class SecurityConfig {
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final TokenService tokenService;
 
-    public SecurityConfig(JwtTokenProvider jwtTokenProvider) {
+    public SecurityConfig(JwtTokenProvider jwtTokenProvider, TokenService tokenService) {
         this.jwtTokenProvider = jwtTokenProvider;
+        this.tokenService = tokenService;
     }
 
     @Bean
@@ -48,7 +53,7 @@ public class SecurityConfig {
                         .requestMatchers("/ws/**").permitAll()
                         .anyRequest().authenticated()
                 )
-                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, tokenService), UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }
@@ -74,5 +79,4 @@ public class SecurityConfig {
         source.registerCorsConfiguration("/**", configuration);
         return source;
     }
-
 }

--- a/src/main/java/com/rinoimob/domain/dto/CreateTenantRoleRequest.java
+++ b/src/main/java/com/rinoimob/domain/dto/CreateTenantRoleRequest.java
@@ -1,0 +1,9 @@
+package com.rinoimob.domain.dto;
+
+import java.util.List;
+
+public record CreateTenantRoleRequest(
+    String name,
+    String description,
+    List<String> permissions
+) {}

--- a/src/main/java/com/rinoimob/domain/dto/InviteUserRequest.java
+++ b/src/main/java/com/rinoimob/domain/dto/InviteUserRequest.java
@@ -1,0 +1,10 @@
+package com.rinoimob.domain.dto;
+
+import java.util.UUID;
+
+public record InviteUserRequest(
+    String email,
+    String firstName,
+    String lastName,
+    UUID roleId
+) {}

--- a/src/main/java/com/rinoimob/domain/dto/TenantRoleResponse.java
+++ b/src/main/java/com/rinoimob/domain/dto/TenantRoleResponse.java
@@ -1,0 +1,13 @@
+package com.rinoimob.domain.dto;
+
+import java.util.List;
+import java.util.UUID;
+
+public record TenantRoleResponse(
+    UUID id,
+    UUID tenantId,
+    String name,
+    String description,
+    Boolean isSystem,
+    List<String> permissions
+) {}

--- a/src/main/java/com/rinoimob/domain/dto/UpdateTenantRoleRequest.java
+++ b/src/main/java/com/rinoimob/domain/dto/UpdateTenantRoleRequest.java
@@ -1,0 +1,9 @@
+package com.rinoimob.domain.dto;
+
+import java.util.List;
+
+public record UpdateTenantRoleRequest(
+    String name,
+    String description,
+    List<String> permissions
+) {}

--- a/src/main/java/com/rinoimob/domain/dto/UpdateUserRoleRequest.java
+++ b/src/main/java/com/rinoimob/domain/dto/UpdateUserRoleRequest.java
@@ -1,0 +1,5 @@
+package com.rinoimob.domain.dto;
+
+import java.util.UUID;
+
+public record UpdateUserRoleRequest(UUID roleId) {}

--- a/src/main/java/com/rinoimob/domain/dto/UserManagementResponse.java
+++ b/src/main/java/com/rinoimob/domain/dto/UserManagementResponse.java
@@ -1,0 +1,16 @@
+package com.rinoimob.domain.dto;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record UserManagementResponse(
+    UUID id,
+    String email,
+    String firstName,
+    String lastName,
+    boolean active,
+    String systemRole,
+    UUID tenantRoleId,
+    String tenantRoleName,
+    LocalDateTime createdAt
+) {}

--- a/src/main/java/com/rinoimob/domain/entity/RolePermission.java
+++ b/src/main/java/com/rinoimob/domain/entity/RolePermission.java
@@ -1,0 +1,25 @@
+package com.rinoimob.domain.entity;
+
+import jakarta.persistence.*;
+import java.util.UUID;
+
+@Entity
+@Table(name = "role_permissions")
+public class RolePermission {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private UUID id;
+
+    @Column(name = "role_id", nullable = false)
+    private UUID roleId;
+
+    @Column(nullable = false)
+    private String permission;
+
+    public UUID getId() { return id; }
+    public void setId(UUID id) { this.id = id; }
+    public UUID getRoleId() { return roleId; }
+    public void setRoleId(UUID roleId) { this.roleId = roleId; }
+    public String getPermission() { return permission; }
+    public void setPermission(String permission) { this.permission = permission; }
+}

--- a/src/main/java/com/rinoimob/domain/entity/TenantRole.java
+++ b/src/main/java/com/rinoimob/domain/entity/TenantRole.java
@@ -1,0 +1,57 @@
+package com.rinoimob.domain.entity;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "tenant_roles")
+public class TenantRole {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private UUID id;
+
+    @Column(name = "tenant_id", nullable = false)
+    private UUID tenantId;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column
+    private String description;
+
+    @Column(name = "is_system", nullable = false)
+    private Boolean isSystem = false;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+
+    public UUID getId() { return id; }
+    public void setId(UUID id) { this.id = id; }
+    public UUID getTenantId() { return tenantId; }
+    public void setTenantId(UUID tenantId) { this.tenantId = tenantId; }
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+    public Boolean getIsSystem() { return isSystem; }
+    public void setIsSystem(Boolean isSystem) { this.isSystem = isSystem; }
+    public LocalDateTime getCreatedAt() { return createdAt; }
+    public void setCreatedAt(LocalDateTime createdAt) { this.createdAt = createdAt; }
+    public LocalDateTime getUpdatedAt() { return updatedAt; }
+    public void setUpdatedAt(LocalDateTime updatedAt) { this.updatedAt = updatedAt; }
+}

--- a/src/main/java/com/rinoimob/domain/entity/User.java
+++ b/src/main/java/com/rinoimob/domain/entity/User.java
@@ -39,8 +39,14 @@ public class User {
     private Boolean active = true;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    private Role role = Role.USER;
+    @Column
+    private Role role;
+
+    @Column(name = "system_role")
+    private String systemRole;
+
+    @Column(name = "tenant_role_id")
+    private UUID tenantRoleId;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "verification_status")
@@ -69,4 +75,7 @@ public class User {
         updatedAt = LocalDateTime.now();
     }
 
+    public boolean isSystemUser() {
+        return systemRole != null;
+    }
 }

--- a/src/main/java/com/rinoimob/domain/enums/Permission.java
+++ b/src/main/java/com/rinoimob/domain/enums/Permission.java
@@ -1,0 +1,35 @@
+package com.rinoimob.domain.enums;
+
+import java.util.Arrays;
+import java.util.List;
+
+public enum Permission {
+    LEADS_READ("leads:read"),
+    LEADS_WRITE("leads:write"),
+    PROPERTIES_READ("properties:read"),
+    PROPERTIES_WRITE("properties:write"),
+    TASKS_READ("tasks:read"),
+    TASKS_WRITE("tasks:write"),
+    TASK_TYPES_READ("task_types:read"),
+    TASK_TYPES_WRITE("task_types:write"),
+    CATEGORIES_READ("categories:read"),
+    CATEGORIES_WRITE("categories:write"),
+    WHATSAPP_READ("whatsapp:read"),
+    WHATSAPP_WRITE("whatsapp:write"),
+    USERS_READ("users:read"),
+    USERS_WRITE("users:write"),
+    ROLES_READ("roles:read"),
+    ROLES_WRITE("roles:write"),
+    SETTINGS_MANAGE("settings:manage"),
+    REPORTS_READ("reports:read");
+
+    private final String value;
+
+    Permission(String value) { this.value = value; }
+
+    public String getValue() { return value; }
+
+    public static List<String> allValues() {
+        return Arrays.stream(values()).map(Permission::getValue).toList();
+    }
+}

--- a/src/main/java/com/rinoimob/domain/repository/RolePermissionRepository.java
+++ b/src/main/java/com/rinoimob/domain/repository/RolePermissionRepository.java
@@ -1,0 +1,18 @@
+package com.rinoimob.domain.repository;
+
+import com.rinoimob.domain.entity.RolePermission;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
+import java.util.List;
+import java.util.UUID;
+
+public interface RolePermissionRepository extends JpaRepository<RolePermission, UUID> {
+    List<RolePermission> findByRoleId(UUID roleId);
+
+    @Transactional
+    void deleteByRoleId(UUID roleId);
+
+    @Query("SELECT rp.permission FROM RolePermission rp WHERE rp.roleId = :roleId")
+    List<String> findPermissionValuesByRoleId(UUID roleId);
+}

--- a/src/main/java/com/rinoimob/domain/repository/TenantRoleRepository.java
+++ b/src/main/java/com/rinoimob/domain/repository/TenantRoleRepository.java
@@ -1,0 +1,13 @@
+package com.rinoimob.domain.repository;
+
+import com.rinoimob.domain.entity.TenantRole;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface TenantRoleRepository extends JpaRepository<TenantRole, UUID> {
+    List<TenantRole> findByTenantId(UUID tenantId);
+    Optional<TenantRole> findByTenantIdAndId(UUID tenantId, UUID id);
+    boolean existsByTenantIdAndName(UUID tenantId, String name);
+}

--- a/src/main/java/com/rinoimob/domain/repository/UserRepository.java
+++ b/src/main/java/com/rinoimob/domain/repository/UserRepository.java
@@ -23,4 +23,5 @@ public interface UserRepository extends JpaRepository<User, UUID> {
 
     List<User> findByTenantIdAndActive(UUID tenantId, Boolean active);
 
+    boolean existsByTenantRoleId(UUID tenantRoleId);
 }

--- a/src/main/java/com/rinoimob/service/TenantRoleService.java
+++ b/src/main/java/com/rinoimob/service/TenantRoleService.java
@@ -1,0 +1,147 @@
+package com.rinoimob.service;
+
+import com.rinoimob.domain.dto.CreateTenantRoleRequest;
+import com.rinoimob.domain.dto.TenantRoleResponse;
+import com.rinoimob.domain.dto.UpdateTenantRoleRequest;
+import com.rinoimob.domain.entity.RolePermission;
+import com.rinoimob.domain.entity.TenantRole;
+import com.rinoimob.domain.entity.User;
+import com.rinoimob.domain.enums.Permission;
+import com.rinoimob.domain.repository.RolePermissionRepository;
+import com.rinoimob.domain.repository.TenantRoleRepository;
+import com.rinoimob.domain.repository.UserRepository;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+public class TenantRoleService {
+    private final TenantRoleRepository tenantRoleRepository;
+    private final RolePermissionRepository rolePermissionRepository;
+    private final UserRepository userRepository;
+
+    public TenantRoleService(TenantRoleRepository tenantRoleRepository,
+                              RolePermissionRepository rolePermissionRepository,
+                              UserRepository userRepository) {
+        this.tenantRoleRepository = tenantRoleRepository;
+        this.rolePermissionRepository = rolePermissionRepository;
+        this.userRepository = userRepository;
+    }
+
+    public List<TenantRoleResponse> listRoles(UUID tenantId) {
+        return tenantRoleRepository.findByTenantId(tenantId).stream()
+                .map(role -> toResponse(role, rolePermissionRepository.findPermissionValuesByRoleId(role.getId())))
+                .toList();
+    }
+
+    public TenantRoleResponse getRole(UUID tenantId, UUID roleId) {
+        TenantRole role = tenantRoleRepository.findByTenantIdAndId(tenantId, roleId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Role not found"));
+        List<String> permissions = rolePermissionRepository.findPermissionValuesByRoleId(roleId);
+        return toResponse(role, permissions);
+    }
+
+    @Transactional
+    public TenantRoleResponse createRole(UUID tenantId, CreateTenantRoleRequest request) {
+        if (tenantRoleRepository.existsByTenantIdAndName(tenantId, request.name())) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "Role name already exists");
+        }
+        TenantRole role = new TenantRole();
+        role.setTenantId(tenantId);
+        role.setName(request.name());
+        role.setDescription(request.description());
+        role.setIsSystem(false);
+        TenantRole saved = tenantRoleRepository.save(role);
+        savePermissions(saved.getId(), request.permissions());
+        return toResponse(saved, request.permissions() != null ? request.permissions() : List.of());
+    }
+
+    @Transactional
+    public TenantRoleResponse updateRole(UUID tenantId, UUID roleId, UpdateTenantRoleRequest request) {
+        TenantRole role = tenantRoleRepository.findByTenantIdAndId(tenantId, roleId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Role not found"));
+        if (Boolean.TRUE.equals(role.getIsSystem())) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Cannot modify system roles");
+        }
+        role.setName(request.name());
+        role.setDescription(request.description());
+        TenantRole saved = tenantRoleRepository.save(role);
+        rolePermissionRepository.deleteByRoleId(roleId);
+        savePermissions(roleId, request.permissions());
+        return toResponse(saved, request.permissions() != null ? request.permissions() : List.of());
+    }
+
+    @Transactional
+    public void deleteRole(UUID tenantId, UUID roleId) {
+        TenantRole role = tenantRoleRepository.findByTenantIdAndId(tenantId, roleId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Role not found"));
+        if (Boolean.TRUE.equals(role.getIsSystem())) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Cannot delete system roles");
+        }
+        boolean hasUsers = userRepository.existsByTenantRoleId(roleId);
+        if (hasUsers) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "Role is assigned to users");
+        }
+        rolePermissionRepository.deleteByRoleId(roleId);
+        tenantRoleRepository.delete(role);
+    }
+
+    @Transactional
+    public void seedDefaultRoles(UUID tenantId) {
+        createSystemRole(tenantId, "Administrador", "Acesso total ao sistema", Permission.allValues());
+        createSystemRole(tenantId, "Corretor", "Acesso a leads, tarefas, imóveis e WhatsApp",
+                Arrays.asList("leads:read", "leads:write", "tasks:read", "tasks:write",
+                        "properties:read", "properties:write", "whatsapp:read", "whatsapp:write"));
+        createSystemRole(tenantId, "Visualizador", "Acesso de leitura apenas",
+                Arrays.asList("leads:read", "properties:read", "tasks:read", "categories:read",
+                        "whatsapp:read", "reports:read"));
+    }
+
+    public List<String> getPermissionsForUser(User user) {
+        if (user.getSystemRole() != null) {
+            return Permission.allValues();
+        }
+        if (user.getTenantRoleId() != null) {
+            return rolePermissionRepository.findPermissionValuesByRoleId(user.getTenantRoleId());
+        }
+        return List.of();
+    }
+
+    private void createSystemRole(UUID tenantId, String name, String description, List<String> permissions) {
+        if (!tenantRoleRepository.existsByTenantIdAndName(tenantId, name)) {
+            TenantRole role = new TenantRole();
+            role.setTenantId(tenantId);
+            role.setName(name);
+            role.setDescription(description);
+            role.setIsSystem(true);
+            TenantRole saved = tenantRoleRepository.save(role);
+            savePermissions(saved.getId(), permissions);
+        }
+    }
+
+    private void savePermissions(UUID roleId, List<String> permissions) {
+        if (permissions == null) return;
+        for (String perm : permissions) {
+            RolePermission rp = new RolePermission();
+            rp.setRoleId(roleId);
+            rp.setPermission(perm);
+            rolePermissionRepository.save(rp);
+        }
+    }
+
+    private TenantRoleResponse toResponse(TenantRole role, List<String> permissions) {
+        return new TenantRoleResponse(
+                role.getId(),
+                role.getTenantId(),
+                role.getName(),
+                role.getDescription(),
+                role.getIsSystem(),
+                permissions
+        );
+    }
+}

--- a/src/main/java/com/rinoimob/service/UserManagementService.java
+++ b/src/main/java/com/rinoimob/service/UserManagementService.java
@@ -1,0 +1,144 @@
+package com.rinoimob.service;
+
+import com.rinoimob.domain.dto.InviteUserRequest;
+import com.rinoimob.domain.dto.UserManagementResponse;
+import com.rinoimob.domain.entity.GlobalCredential;
+import com.rinoimob.domain.entity.TenantRole;
+import com.rinoimob.domain.entity.User;
+import com.rinoimob.domain.entity.VerificationToken;
+import com.rinoimob.domain.enums.VerificationStatus;
+import com.rinoimob.domain.repository.GlobalCredentialRepository;
+import com.rinoimob.domain.repository.TenantRoleRepository;
+import com.rinoimob.domain.repository.UserRepository;
+import com.rinoimob.domain.repository.VerificationTokenRepository;
+import com.rinoimob.service.auth.PasswordEncoderService;
+import com.rinoimob.service.auth.TokenService;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+public class UserManagementService {
+    private final UserRepository userRepository;
+    private final TenantRoleRepository tenantRoleRepository;
+    private final TokenService tokenService;
+    private final TenantRoleService tenantRoleService;
+    private final GlobalCredentialRepository globalCredentialRepository;
+    private final PasswordEncoderService passwordEncoderService;
+    private final VerificationTokenRepository verificationTokenRepository;
+
+    public UserManagementService(UserRepository userRepository,
+                                  TenantRoleRepository tenantRoleRepository,
+                                  TokenService tokenService,
+                                  TenantRoleService tenantRoleService,
+                                  GlobalCredentialRepository globalCredentialRepository,
+                                  PasswordEncoderService passwordEncoderService,
+                                  VerificationTokenRepository verificationTokenRepository) {
+        this.userRepository = userRepository;
+        this.tenantRoleRepository = tenantRoleRepository;
+        this.tokenService = tokenService;
+        this.tenantRoleService = tenantRoleService;
+        this.globalCredentialRepository = globalCredentialRepository;
+        this.passwordEncoderService = passwordEncoderService;
+        this.verificationTokenRepository = verificationTokenRepository;
+    }
+
+    public List<UserManagementResponse> listUsers(UUID tenantId) {
+        return userRepository.findByTenantId(tenantId).stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    @Transactional
+    public UserManagementResponse inviteUser(UUID tenantId, InviteUserRequest request) {
+        String normalizedEmail = request.email().toLowerCase();
+
+        if (userRepository.existsByEmailAndTenantId(normalizedEmail, tenantId)) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "Email already registered in this tenant");
+        }
+
+        tenantRoleRepository.findByTenantIdAndId(tenantId, request.roleId())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Role not found"));
+
+        String tempPassword = UUID.randomUUID().toString();
+        if (globalCredentialRepository.findByEmail(normalizedEmail).isEmpty()) {
+            GlobalCredential credential = new GlobalCredential();
+            credential.setEmail(normalizedEmail);
+            credential.setPasswordHash(passwordEncoderService.encodePassword(tempPassword));
+            globalCredentialRepository.save(credential);
+        }
+
+        User user = new User();
+        user.setTenantId(tenantId);
+        user.setEmail(normalizedEmail);
+        user.setFirstName(request.firstName());
+        user.setLastName(request.lastName());
+        user.setTenantRoleId(request.roleId());
+        user.setVerificationStatus(VerificationStatus.PENDING);
+        user.setActive(true);
+
+        User saved = userRepository.save(user);
+
+        String verificationToken = UUID.randomUUID().toString();
+        VerificationToken token = new VerificationToken();
+        token.setToken(verificationToken);
+        token.setUserId(saved.getId());
+        token.setTokenType("VERIFICATION");
+        token.setExpiresAt(LocalDateTime.now().plusDays(7));
+        verificationTokenRepository.save(token);
+
+        return toResponse(saved);
+    }
+
+    @Transactional
+    public UserManagementResponse assignRole(UUID tenantId, UUID userId, UUID roleId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
+        if ("TENANT_OWNER".equals(user.getSystemRole())) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Cannot change role of TENANT_OWNER");
+        }
+        tenantRoleRepository.findByTenantIdAndId(tenantId, roleId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Role not found"));
+        user.setTenantRoleId(roleId);
+        User saved = userRepository.save(user);
+        tokenService.revokeAllForUser(userId);
+        return toResponse(saved);
+    }
+
+    @Transactional
+    public void deactivateUser(UUID tenantId, UUID userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
+        if ("TENANT_OWNER".equals(user.getSystemRole())) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Cannot deactivate TENANT_OWNER");
+        }
+        user.setActive(false);
+        userRepository.save(user);
+        tokenService.revokeAllForUser(userId);
+    }
+
+    private UserManagementResponse toResponse(User user) {
+        String roleName = null;
+        if (user.getTenantRoleId() != null) {
+            roleName = tenantRoleRepository.findById(user.getTenantRoleId())
+                    .map(TenantRole::getName)
+                    .orElse(null);
+        }
+        return new UserManagementResponse(
+                user.getId(),
+                user.getEmail(),
+                user.getFirstName(),
+                user.getLastName(),
+                Boolean.TRUE.equals(user.getActive()),
+                user.getSystemRole(),
+                user.getTenantRoleId(),
+                roleName,
+                user.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/rinoimob/service/auth/AuthService.java
+++ b/src/main/java/com/rinoimob/service/auth/AuthService.java
@@ -15,13 +15,13 @@ import com.rinoimob.domain.entity.GlobalCredential;
 import com.rinoimob.domain.entity.Tenant;
 import com.rinoimob.domain.entity.User;
 import com.rinoimob.domain.entity.VerificationToken;
-import com.rinoimob.domain.enums.Role;
 import com.rinoimob.domain.enums.VerificationStatus;
 import com.rinoimob.domain.repository.GlobalCredentialRepository;
 import com.rinoimob.domain.repository.TenantRepository;
 import com.rinoimob.domain.repository.UserRepository;
 import com.rinoimob.domain.repository.VerificationTokenRepository;
 import com.rinoimob.context.TenantContext;
+import com.rinoimob.service.TenantRoleService;
 import com.rinoimob.service.email.EmailService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -44,6 +44,8 @@ public class AuthService {
     private final JwtTokenProvider tokenProvider;
     private final PasswordEncoderService passwordEncoderService;
     private final EmailService emailService;
+    private final TenantRoleService tenantRoleService;
+    private final TokenService tokenService;
 
     @Value("${app.verification-token-expiration:86400}")
     private long verificationTokenExpiration;
@@ -57,7 +59,9 @@ public class AuthService {
                        VerificationTokenRepository tokenRepository,
                        JwtTokenProvider tokenProvider,
                        PasswordEncoderService passwordEncoderService,
-                       EmailService emailService) {
+                       EmailService emailService,
+                       TenantRoleService tenantRoleService,
+                       TokenService tokenService) {
         this.userRepository = userRepository;
         this.tenantRepository = tenantRepository;
         this.globalCredentialRepository = globalCredentialRepository;
@@ -65,6 +69,8 @@ public class AuthService {
         this.tokenProvider = tokenProvider;
         this.passwordEncoderService = passwordEncoderService;
         this.emailService = emailService;
+        this.tenantRoleService = tenantRoleService;
+        this.tokenService = tokenService;
     }
 
     @Transactional
@@ -89,7 +95,6 @@ public class AuthService {
         tenant.setSubdomain(normalizedSubdomain);
         Tenant savedTenant = tenantRepository.save(tenant);
 
-        // Create global credential only if this email is new to the platform.
         if (globalCredentialRepository.findByEmail(normalizedEmail).isEmpty()) {
             GlobalCredential credential = new GlobalCredential();
             credential.setEmail(normalizedEmail);
@@ -102,11 +107,13 @@ public class AuthService {
         user.setEmail(normalizedEmail);
         user.setFirstName(request.firstName());
         user.setLastName(request.lastName());
-        user.setRole(Role.TENANT_OWNER);
+        user.setSystemRole("TENANT_OWNER");
         user.setVerificationStatus(VerificationStatus.PENDING);
         user.setActive(true);
 
         User savedUser = userRepository.save(user);
+
+        tenantRoleService.seedDefaultRoles(savedTenant.getId());
 
         String verificationToken = UUID.randomUUID().toString();
         VerificationToken token = new VerificationToken();
@@ -133,7 +140,6 @@ public class AuthService {
             throw new IllegalArgumentException("Email already registered");
         }
 
-        // Create global credential only if this email is new to the platform.
         if (globalCredentialRepository.findByEmail(normalizedEmail).isEmpty()) {
             GlobalCredential credential = new GlobalCredential();
             credential.setEmail(normalizedEmail);
@@ -164,10 +170,6 @@ public class AuthService {
         log.info("User registered: {} in tenant {}", savedUser.getEmail(), tenantId);
     }
 
-    /**
-     * Step 1 of the workspace-selector login flow.
-     * Validates global credentials and returns the list of active workspaces for this identity.
-     */
     @Transactional(readOnly = true)
     public IdentifyResponse identify(String email, String password) {
         String normalizedEmail = email.toLowerCase();
@@ -180,8 +182,8 @@ public class AuthService {
         }
 
         List<TenantSummary> tenants = userRepository.findAllByEmail(normalizedEmail).stream()
-                .filter(User::getActive)
-                .map(user -> tenantRepository.findById(user.getTenantId()).orElse(null))
+                .filter(u -> Boolean.TRUE.equals(u.getActive()))
+                .map(u -> tenantRepository.findById(u.getTenantId()).orElse(null))
                 .filter(t -> t != null && t.getActive())
                 .map(t -> new TenantSummary(t.getId(), t.getName(), t.getSubdomain()))
                 .toList();
@@ -196,10 +198,6 @@ public class AuthService {
         return new IdentifyResponse(preAuthToken, tenants);
     }
 
-    /**
-     * Step 2 of the workspace-selector login flow.
-     * Validates the pre-auth token, checks workspace membership, and issues a full JWT.
-     */
     @Transactional
     public LoginResponse selectTenant(String preAuthToken, UUID tenantId) {
         if (!tokenProvider.isPreAuthToken(preAuthToken) || !tokenProvider.isTokenValid(preAuthToken)) {
@@ -216,24 +214,29 @@ public class AuthService {
         User user = userRepository.findByEmailAndTenantId(email, tenantId)
                 .orElseThrow(() -> new IllegalArgumentException("User not found in workspace"));
 
-        if (!user.getActive()) {
+        if (!Boolean.TRUE.equals(user.getActive())) {
             throw new IllegalArgumentException("Account is disabled");
         }
 
         user.setLastLogin(LocalDateTime.now());
         userRepository.save(user);
 
-        String accessToken = tokenProvider.generateAccessToken(user.getId(), user.getEmail(), user.getRole().toString(), user.getTenantId());
+        List<String> permissions = tenantRoleService.getPermissionsForUser(user);
+        String roleStr = user.getSystemRole() != null ? user.getSystemRole() :
+                         (user.getRole() != null ? user.getRole().toString() : null);
+
+        String accessToken = tokenProvider.generateAccessToken(user.getId(), user.getEmail(), roleStr, user.getTenantId(), permissions);
+        String jti = tokenProvider.getJtiFromToken(accessToken);
+        if (jti != null) {
+            tokenService.store(jti, user.getId(), tokenProvider.getAccessTokenTtlSeconds());
+        }
         String refreshToken = tokenProvider.generateRefreshToken(user.getId(), user.getEmail());
 
         log.info("User logged in: {} in tenant {}", user.getEmail(), tenantId);
 
-        return new LoginResponse(accessToken, refreshToken, 900L, mapToUserDto(user));
+        return new LoginResponse(accessToken, refreshToken, tokenProvider.getAccessTokenTtlSeconds(), mapToUserDto(user));
     }
 
-    /**
-     * Legacy login used by the client website where tenant is resolved from the request host.
-     */
     @Transactional
     public LoginResponse login(LoginRequest request, UUID tenantId) {
         String normalizedEmail = request.email().toLowerCase();
@@ -248,19 +251,35 @@ public class AuthService {
         User user = userRepository.findByEmailAndTenantId(normalizedEmail, tenantId)
                 .orElseThrow(() -> new IllegalArgumentException("Invalid credentials"));
 
-        if (!user.getActive()) {
+        if (!Boolean.TRUE.equals(user.getActive())) {
             throw new IllegalArgumentException("Account is disabled");
         }
 
         user.setLastLogin(LocalDateTime.now());
         userRepository.save(user);
 
-        String accessToken = tokenProvider.generateAccessToken(user.getId(), user.getEmail(), user.getRole().toString(), user.getTenantId());
+        List<String> permissions = tenantRoleService.getPermissionsForUser(user);
+        String roleStr = user.getSystemRole() != null ? user.getSystemRole() :
+                         (user.getRole() != null ? user.getRole().toString() : null);
+
+        String accessToken = tokenProvider.generateAccessToken(user.getId(), user.getEmail(), roleStr, user.getTenantId(), permissions);
+        String jti = tokenProvider.getJtiFromToken(accessToken);
+        if (jti != null) {
+            tokenService.store(jti, user.getId(), tokenProvider.getAccessTokenTtlSeconds());
+        }
         String refreshToken = tokenProvider.generateRefreshToken(user.getId(), user.getEmail());
 
         log.info("User logged in (host-resolved): {}", user.getEmail());
 
-        return new LoginResponse(accessToken, refreshToken, 900L, mapToUserDto(user));
+        return new LoginResponse(accessToken, refreshToken, tokenProvider.getAccessTokenTtlSeconds(), mapToUserDto(user));
+    }
+
+    @Transactional
+    public void logout(UUID userId, String jti) {
+        if (jti != null) {
+            tokenService.revoke(jti);
+        }
+        log.info("User logged out: {}", userId);
     }
 
     @Transactional
@@ -288,15 +307,13 @@ public class AuthService {
     public void requestPasswordReset(String email) {
         String normalizedEmail = email.toLowerCase();
 
-        // Global credential must exist; if not, silently return to avoid enumeration.
         if (globalCredentialRepository.findByEmail(normalizedEmail).isEmpty()) {
             log.info("Password reset requested for non-existent email: {}", normalizedEmail);
             return;
         }
 
-        // Find any membership row to anchor the reset token (any tenant is fine).
         Optional<User> userOpt = userRepository.findAllByEmail(normalizedEmail).stream()
-                .filter(User::getActive)
+                .filter(u -> Boolean.TRUE.equals(u.getActive()))
                 .findFirst();
 
         if (userOpt.isEmpty()) {
@@ -338,7 +355,6 @@ public class AuthService {
         User user = userRepository.findById(resetToken.getUserId())
                 .orElseThrow(() -> new IllegalArgumentException("User not found"));
 
-        // Update the global credential (password shared across all workspaces).
         GlobalCredential credential = globalCredentialRepository.findByEmail(user.getEmail())
                 .orElseThrow(() -> new IllegalArgumentException("Credential not found"));
 
@@ -368,7 +384,6 @@ public class AuthService {
                     tenantSubdomain = tenant.get().getSubdomain();
                 }
             } catch (IllegalArgumentException ignored) {
-                // invalid UUID in context — skip tenant info
             }
         }
 

--- a/src/main/java/com/rinoimob/service/auth/TokenService.java
+++ b/src/main/java/com/rinoimob/service/auth/TokenService.java
@@ -1,0 +1,48 @@
+package com.rinoimob.service.auth;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+@Service
+public class TokenService {
+    private final RedisTemplate<String, String> stringRedisTemplate;
+
+    public TokenService(RedisTemplate<String, String> stringRedisTemplate) {
+        this.stringRedisTemplate = stringRedisTemplate;
+    }
+
+    public void store(String jti, UUID userId, long ttlSeconds) {
+        String tokenKey = "token:" + jti;
+        String userTokensKey = "user_tokens:" + userId;
+        stringRedisTemplate.opsForValue().set(tokenKey, userId.toString(), ttlSeconds, TimeUnit.SECONDS);
+        stringRedisTemplate.opsForSet().add(userTokensKey, jti);
+        stringRedisTemplate.expire(userTokensKey, ttlSeconds, TimeUnit.SECONDS);
+    }
+
+    public boolean isValid(String jti) {
+        return Boolean.TRUE.equals(stringRedisTemplate.hasKey("token:" + jti));
+    }
+
+    public void revoke(String jti) {
+        String tokenKey = "token:" + jti;
+        String userId = stringRedisTemplate.opsForValue().get(tokenKey);
+        if (userId != null) {
+            stringRedisTemplate.delete(tokenKey);
+            stringRedisTemplate.opsForSet().remove("user_tokens:" + userId, jti);
+        }
+    }
+
+    public void revokeAllForUser(UUID userId) {
+        String userTokensKey = "user_tokens:" + userId;
+        Set<String> jtis = stringRedisTemplate.opsForSet().members(userTokensKey);
+        if (jtis != null) {
+            for (String jti : jtis) {
+                stringRedisTemplate.delete("token:" + jti);
+            }
+        }
+        stringRedisTemplate.delete(userTokensKey);
+    }
+}

--- a/src/main/resources/db/migration/V12__roles_permissions.sql
+++ b/src/main/resources/db/migration/V12__roles_permissions.sql
@@ -1,0 +1,32 @@
+-- tenant_roles: roles customizáveis por tenant
+CREATE TABLE IF NOT EXISTS tenant_roles (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    name VARCHAR(100) NOT NULL,
+    description TEXT,
+    is_system BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    UNIQUE (tenant_id, name)
+);
+
+-- role_permissions: permissões de cada role
+CREATE TABLE IF NOT EXISTS role_permissions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    role_id UUID NOT NULL REFERENCES tenant_roles(id) ON DELETE CASCADE,
+    permission VARCHAR(100) NOT NULL,
+    UNIQUE (role_id, permission)
+);
+
+-- Adicionar colunas na tabela users
+ALTER TABLE users ADD COLUMN IF NOT EXISTS system_role VARCHAR(50);
+ALTER TABLE users ADD COLUMN IF NOT EXISTS tenant_role_id UUID REFERENCES tenant_roles(id);
+
+-- Migrar TENANT_OWNER e TENANT_ADMIN para system_role
+UPDATE users SET system_role = role WHERE role IN ('TENANT_OWNER', 'TENANT_ADMIN');
+
+-- Tornar role nullable para usuários com tenant_role
+ALTER TABLE users ALTER COLUMN role DROP NOT NULL;
+ALTER TABLE users ALTER COLUMN role SET DEFAULT NULL;
+-- Limpar role para quem já tem system_role
+UPDATE users SET role = NULL WHERE system_role IS NOT NULL;

--- a/src/test/java/com/rinoimob/service/auth/AuthServiceTest.java
+++ b/src/test/java/com/rinoimob/service/auth/AuthServiceTest.java
@@ -13,6 +13,7 @@ import com.rinoimob.domain.repository.GlobalCredentialRepository;
 import com.rinoimob.domain.repository.TenantRepository;
 import com.rinoimob.domain.repository.UserRepository;
 import com.rinoimob.domain.repository.VerificationTokenRepository;
+import com.rinoimob.service.TenantRoleService;
 import com.rinoimob.service.email.EmailService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -58,6 +59,12 @@ class AuthServiceTest {
 
     @Mock
     private EmailService emailService;
+
+    @Mock
+    private TenantRoleService tenantRoleService;
+
+    @Mock
+    private TokenService tokenService;
 
     @InjectMocks
     private AuthService authService;
@@ -137,8 +144,11 @@ class AuthServiceTest {
         when(globalCredentialRepository.findByEmail(request.email())).thenReturn(Optional.of(credential));
         when(passwordEncoderService.verifyPassword(request.password(), credential.getPasswordHash())).thenReturn(true);
         when(userRepository.findByEmailAndTenantId(request.email(), tenantId)).thenReturn(Optional.of(user));
-        when(tokenProvider.generateAccessToken(userId, request.email(), Role.USER.toString(), tenantId))
+        when(tenantRoleService.getPermissionsForUser(user)).thenReturn(List.of());
+        when(tokenProvider.generateAccessToken(any(), anyString(), anyString(), any(), any()))
                 .thenReturn("access_token");
+        when(tokenProvider.getJtiFromToken("access_token")).thenReturn("test-jti");
+        when(tokenProvider.getAccessTokenTtlSeconds()).thenReturn(900L);
         when(tokenProvider.generateRefreshToken(userId, request.email())).thenReturn("refresh_token");
 
         var response = authService.login(request, tenantId);
@@ -290,7 +300,7 @@ class AuthServiceTest {
 
         verify(tenantRepository, times(1)).save(any(Tenant.class));
         verify(globalCredentialRepository, times(1)).save(any(GlobalCredential.class));
-        verify(userRepository, times(1)).save(argThat(u -> u.getRole() == Role.TENANT_OWNER));
+        verify(userRepository, times(1)).save(argThat(u -> "TENANT_OWNER".equals(u.getSystemRole())));
         verify(tokenRepository, times(1)).save(any(VerificationToken.class));
         verify(emailService, times(1)).sendVerificationEmail(eq(request.email()), anyString());
     }


### PR DESCRIPTION
## Phase 5 — Custom Roles & Permissions

### Backend changes
- **TokenService**: JWT jti whitelist in Redis — immediate revocation on logout/role change
- **JwtTokenProvider**: `jti` + `permissions[]` claims in access tokens
- **JwtAuthenticationFilter**: validates jti in Redis; loads `PERMISSION_*` authorities
- **V12 migration**: `tenant_roles`, `role_permissions` tables; `system_role` + `tenant_role_id` in users
- **Permission enum**: 18 permissions across all modules (leads, properties, tasks, whatsapp, team, system)
- **TenantRoleService**: CRUD + `seedDefaultRoles()` called on signup → Administrador / Corretor / Visualizador
- **UserManagementService**: invite, assignRole (revokes old JWT), deactivate
- **TenantRoleController**: `/api/v1/roles`
- **UserManagementController**: `/api/v1/team/users`
- **AuthController**: `POST /logout` revokes jti
- **@PreAuthorize** on all existing controllers